### PR TITLE
Pin pdd-action to a commit hash

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54


### PR DESCRIPTION
Fixes CodeQL alert [#6](https://github.com/andreychh/tgen/security/code-scanning/6).

`volodya-lombrozo/pdd-action` was referenced by `@master` branch — a mutable ref that can change at any time. A supply chain attack could replace the action with malicious code.

Pinned to a specific commit hash to ensure the action is immutable.