### PR TITLE
Add link extraction to field descriptions

### DIFF
--- a/parsing/field_description.go
+++ b/parsing/field_description.go
@@ -24,3 +24,13 @@ func (d ObjectFieldDescription) Value() (string, error) {
 	}
 	return strings.TrimPrefix(d.selection.Text(), "Optional. "), nil
 }
+
+func (d ObjectFieldDescription) Links() []string {
+	var links []string
+	for a := range d.selection.Find("a").All() {
+		if href, ok := a.Attr("href"); ok {
+			links = append(links, href)
+		}
+	}
+	return links
+}

--- a/parsing/method_field.go
+++ b/parsing/method_field.go
@@ -26,7 +26,7 @@ func (f MethodField) IsOptional() Optionality {
 	return NewMethodFieldOptionality(f.selection.Find("td").At(2))
 }
 
-//nolint:ireturn // RawValue is the intentional public contract of Field
-func (f MethodField) Description() RawValue {
+//nolint:ireturn // FieldDescription is the intentional public contract of Field
+func (f MethodField) Description() FieldDescription {
 	return NewMethodFieldDescription(f.selection.Find("td").At(3))
 }

--- a/parsing/method_field_description.go
+++ b/parsing/method_field_description.go
@@ -23,3 +23,13 @@ func (d MethodFieldDescription) Value() (string, error) {
 	}
 	return d.selection.Text(), nil
 }
+
+func (d MethodFieldDescription) Links() []string {
+	var links []string
+	for a := range d.selection.Find("a").All() {
+		if href, ok := a.Attr("href"); ok {
+			links = append(links, href)
+		}
+	}
+	return links
+}

--- a/parsing/object_field.go
+++ b/parsing/object_field.go
@@ -28,7 +28,7 @@ func (f ObjectField) IsOptional() Optionality {
 	return NewObjectFieldOptionality(f.selection.Find("td").At(2))
 }
 
-//nolint:ireturn // RawValue is the intentional public contract of Field
-func (f ObjectField) Description() RawValue {
+//nolint:ireturn // FieldDescription is the intentional public contract of Field
+func (f ObjectField) Description() FieldDescription {
 	return NewObjectFieldDescription(f.selection.Find("td").At(2))
 }

--- a/parsing/parsing.go
+++ b/parsing/parsing.go
@@ -7,9 +7,16 @@ type Optionality interface {
 	Value() (bool, error)
 }
 
+// FieldDescription represents the description column of a field table row.
+type FieldDescription interface {
+	RawValue
+	// Links returns the hrefs of all anchor tags found in the description HTML.
+	Links() []string
+}
+
 type Field interface {
 	Key() FieldKey
 	Type() TypeTree
 	IsOptional() Optionality
-	Description() RawValue
+	Description() FieldDescription
 }


### PR DESCRIPTION
This PR introduces the `FieldDescription` interface that extends `RawValue` with a `Links() []string` method, giving callers structured access to anchor hrefs in description HTML without re-parsing text.

Both `ObjectFieldDescription` and `MethodFieldDescription` now implement `Links()` by querying all `<a>` elements in the description selection. `Field.Description()` return type is updated from `RawValue` to `FieldDescription` across the codebase.

Closes #95