### PR TITLE
Add `DiscriminatedObject` generation for the `python` target

### DIFF
--- a/rendering/python/discriminated_object.go
+++ b/rendering/python/discriminated_object.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package python
+
+import "github.com/andreychh/tgen/model/explicit"
+
+type DiscriminatedObject struct {
+	inner explicit.DiscriminatedObject
+}
+
+func NewDiscriminatedObject(v explicit.DiscriminatedObject) DiscriminatedObject {
+	return DiscriminatedObject{inner: v}
+}
+
+func (o DiscriminatedObject) Name() ClassName {
+	return NewClassName(o.inner.Name())
+}
+
+func (o DiscriminatedObject) Doc() DocString {
+	return NewClassDocString(o.inner.Reference(), o.inner.Description())
+}
+
+func (o DiscriminatedObject) Fields() DiscriminatedObjectFields {
+	return NewDiscriminatedObjectFields(o.inner.Fields())
+}

--- a/rendering/python/discriminated_object_fields.go
+++ b/rendering/python/discriminated_object_fields.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package python
+
+import (
+	"iter"
+
+	"github.com/andreychh/tgen/model/explicit"
+	"github.com/andreychh/tgen/pkg/iters"
+)
+
+// DiscriminatedObjectFields groups the free fields and discriminator of a
+// variant for Python code generation.
+type DiscriminatedObjectFields struct {
+	inner explicit.Fields
+}
+
+// NewDiscriminatedObjectFields constructs a DiscriminatedObjectFields from
+// parsed variant fields.
+func NewDiscriminatedObjectFields(f explicit.Fields) DiscriminatedObjectFields {
+	return DiscriminatedObjectFields{inner: f}
+}
+
+// Free returns the fields that appear in the generated struct, excluding the
+// discriminator.
+func (f DiscriminatedObjectFields) Free() iter.Seq[Field] {
+	return iters.NewMappedSeq(f.inner.Free(), NewField)
+}
+
+// Discriminator returns the discriminator field of this variant.
+func (f DiscriminatedObjectFields) Discriminator() Discriminator {
+	return NewDiscriminator(f.inner.Discriminator())
+}

--- a/rendering/python/discriminator.go
+++ b/rendering/python/discriminator.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package python
+
+import "github.com/andreychh/tgen/model/explicit"
+
+// Discriminator represents the discriminator field of a variant for Python code generation.
+type Discriminator struct {
+	inner explicit.Discriminator
+}
+
+// NewDiscriminator constructs a Discriminator from a parsed discriminator.
+func NewDiscriminator(d explicit.Discriminator) Discriminator {
+	return Discriminator{inner: d}
+}
+
+// Key returns the discriminator field key (e.g. type from type="emoji").
+func (d Discriminator) Key() Key {
+	return NewKey(d.inner.Key())
+}
+
+// Value returns the fixed discriminator value for this variant (e.g. "emoji").
+func (d Discriminator) Value() DiscriminatorValue {
+	return NewDiscriminatorValue(d.inner.Value())
+}

--- a/rendering/python/discriminator_value.go
+++ b/rendering/python/discriminator_value.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package python
+
+import "github.com/andreychh/tgen/model"
+
+// DiscriminatorValue represents the fixed discriminator string of a variant adapted for Python code generation.
+type DiscriminatorValue struct {
+	inner model.DiscriminatorValue
+}
+
+// NewDiscriminatorValue constructs a DiscriminatorValue from a parsed discriminator value.
+func NewDiscriminatorValue(v model.DiscriminatorValue) DiscriminatorValue {
+	return DiscriminatorValue{inner: v}
+}
+
+// AsString returns the discriminator value as a string.
+func (v DiscriminatorValue) AsString() (string, error) {
+	return v.inner.AsString()
+}

--- a/rendering/python/key.go
+++ b/rendering/python/key.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package python
+
+import "github.com/andreychh/tgen/model"
+
+// Key represents a field key adapted for Python code generation.
+type Key struct {
+	inner model.Key
+}
+
+// NewKey constructs a Key from a parsed field key.
+func NewKey(k model.Key) Key {
+	return Key{inner: k}
+}
+
+// AsString returns the key as a Go identifier string.
+func (k Key) AsString() (string, error) {
+	return k.inner.AsString()
+}

--- a/rendering/python/specification.go
+++ b/rendering/python/specification.go
@@ -22,6 +22,18 @@ func (s Specification) Objects() iter.Seq[Object] {
 	return iters.NewMappedSeq(s.inner.Objects(), NewObject)
 }
 
+func (s Specification) DiscriminatedObjects() iter.Seq[DiscriminatedObject] {
+	return func(yield func(DiscriminatedObject) bool) {
+		for u := range s.inner.DiscriminatedUnions() {
+			for v := range u.Variants() {
+				if !yield(NewDiscriminatedObject(v)) {
+					return
+				}
+			}
+		}
+	}
+}
+
 func (s Specification) Release() Release {
 	return NewRelease(s.inner.Release())
 }

--- a/rendering/python/template.go
+++ b/rendering/python/template.go
@@ -25,8 +25,9 @@ func (t Template) Value() (*template.Template, error) {
 	return template.New("").
 		Option("missingkey=error").
 		Funcs(template.FuncMap{
-			"objects": slices.Collect[Object],
-			"fields":  slices.Collect[Field],
+			"objects":               slices.Collect[Object],
+			"discriminated_objects": slices.Collect[DiscriminatedObject],
+			"fields":                slices.Collect[Field],
 		}).
 		ParseFS(templates, "templates/*.tmpl")
 }

--- a/rendering/python/templates/discriminated_object.tmpl
+++ b/rendering/python/templates/discriminated_object.tmpl
@@ -1,0 +1,18 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- define "discriminated_object"}} {{/*gotype: github.com/andreychh/tgen/rendering/python.DiscriminatedObject*/}}
+class {{.Name.AsString}}(BaseModel):
+    {{.Doc.AsString}}
+    model_config = ConfigDict(
+        extra="forbid",
+        alias_generator=lambda s: s.removesuffix("_"),
+        populate_by_name=True,
+    )
+
+    {{.Fields.Discriminator.Key.AsString}}: Literal["{{.Fields.Discriminator.Value.AsString}}"]
+{{- range .Fields.Free | fields}} {{/*gotype: github.com/andreychh/tgen/rendering/python.Field*/}}
+    {{.Name.AsString}}: {{.Annotation.AsString}}
+    {{.Doc.AsString}}
+{{- end}}
+{{- end}}

--- a/rendering/python/templates/objects.tmpl
+++ b/rendering/python/templates/objects.tmpl
@@ -13,5 +13,9 @@ from pydantic import BaseModel, ConfigDict
 {{template "object" . }}
 {{- end }}
 
+{{- range .Spec.DiscriminatedObjects | discriminated_objects}} {{/*gotype: github.com/andreychh/tgen/rendering/python.DiscriminatedObject*/}}
+
+{{template "discriminated_object" . }}
+{{- end }}
 
 {{- end }}


### PR DESCRIPTION
This PR adds `DiscriminatedObject` generation to the `rendering/python` package, producing pydantic `BaseModel` subclasses with a `Literal` discriminator field for each variant.

Discriminator fields are rendered as `Literal["value"]` annotations, which lets pydantic resolve union variants automatically without custom deserialization logic.

Closes #138