### PR TITLE
Add `unions.py` and `__init__.py` generation to Python target

### DIFF
--- a/rendering/python/artifacts.go
+++ b/rendering/python/artifacts.go
@@ -29,6 +29,8 @@ func (a Artifacts) Value() (rendering.Artifacts, error) {
 	}
 	ctx := NewGenerationContext(NewSpecification(a.spec), rendering.NewSnapshot(a.snapshot))
 	return rendering.Artifacts{
-		"objects.py": rendering.NewTemplateView(tmpl, "objects", ctx),
+		"__init__.py": rendering.NewTemplateView(tmpl, "init", ctx),
+		"objects.py":  rendering.NewTemplateView(tmpl, "objects", ctx),
+		"unions.py":   rendering.NewTemplateView(tmpl, "unions", ctx),
 	}, nil
 }

--- a/rendering/python/discriminated_union.go
+++ b/rendering/python/discriminated_union.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package python
+
+import (
+	"github.com/andreychh/tgen/model/explicit"
+)
+
+type DiscriminatedUnion struct {
+	inner explicit.DiscriminatedUnion
+}
+
+func NewDiscriminatedUnion(u explicit.DiscriminatedUnion) DiscriminatedUnion {
+	return DiscriminatedUnion{inner: u}
+}
+
+func (i DiscriminatedUnion) Name() ClassName {
+	return NewClassName(i.inner.Name())
+}
+
+func (i DiscriminatedUnion) Doc() DocString {
+	return NewDocString(i.inner.Description(), 0)
+}
+
+func (i DiscriminatedUnion) DiscriminatorKey() Key {
+	return NewKey(i.inner.DiscriminatorKey())
+}
+
+func (i DiscriminatedUnion) Variants() Variants {
+	return NewVariants(i.inner.Variants())
+}

--- a/rendering/python/specification.go
+++ b/rendering/python/specification.go
@@ -34,6 +34,10 @@ func (s Specification) DiscriminatedObjects() iter.Seq[DiscriminatedObject] {
 	}
 }
 
+func (s Specification) DiscriminatedUnions() iter.Seq[DiscriminatedUnion] {
+	return iters.NewMappedSeq(s.inner.DiscriminatedUnions(), NewDiscriminatedUnion)
+}
+
 func (s Specification) Release() Release {
 	return NewRelease(s.inner.Release())
 }

--- a/rendering/python/template.go
+++ b/rendering/python/template.go
@@ -27,6 +27,7 @@ func (t Template) Value() (*template.Template, error) {
 		Funcs(template.FuncMap{
 			"objects":               slices.Collect[Object],
 			"discriminated_objects": slices.Collect[DiscriminatedObject],
+			"discriminated_unions":  slices.Collect[DiscriminatedUnion],
 			"fields":                slices.Collect[Field],
 		}).
 		ParseFS(templates, "templates/*.tmpl")

--- a/rendering/python/templates/discriminated_union.tmpl
+++ b/rendering/python/templates/discriminated_union.tmpl
@@ -1,0 +1,9 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- define "discriminated_union"}} {{/*gotype: github.com/andreychh/tgen/rendering/python.DiscriminatedUnion*/}}
+{{.Name.AsString}} = Annotated[
+    {{.Variants.AsString}},
+    Field(discriminator="{{.DiscriminatorKey.AsString}}"),
+]
+{{- end}}

--- a/rendering/python/templates/init.tmpl
+++ b/rendering/python/templates/init.tmpl
@@ -1,0 +1,15 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- define "init"}} {{/*gotype: github.com/andreychh/tgen/rendering/python.GenerationContext*/}}
+{{- template "header" .}}
+
+from . import objects as _obj, unions as _uni
+from .objects import *
+from .unions import *
+
+_ns = {**vars(_obj), **vars(_uni)}
+for _v in vars(_obj).values():
+    if isinstance(_v, type) and issubclass(_v, BaseModel) and _v.__module__ == _obj.__name__:
+        _v.model_rebuild(_types_namespace=_ns, raise_errors=False)
+{{- end}}

--- a/rendering/python/templates/objects.tmpl
+++ b/rendering/python/templates/objects.tmpl
@@ -6,6 +6,9 @@
 
 from __future__ import annotations
 
+from io import IOBase
+from typing import NewType, Literal
+
 from pydantic import BaseModel, ConfigDict
 
 {{- range .Spec.Objects | objects}} {{/*gotype: github.com/andreychh/tgen/rendering/python.Object*/}}
@@ -17,5 +20,26 @@ from pydantic import BaseModel, ConfigDict
 
 {{template "discriminated_object" . }}
 {{- end }}
+
+class InaccessibleMessage(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        alias_generator=lambda s: s.removesuffix("_"),
+        populate_by_name=True,
+    )
+    chat: Chat
+    message_id: int
+    date: Literal[0]
+
+
+class Upload(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    name: str
+    reader: IOBase
+
+
+FileID = NewType("FileID", str)
+ID = NewType("ID", int)
+Username = NewType("Username", str)
 
 {{- end }}

--- a/rendering/python/templates/unions.tmpl
+++ b/rendering/python/templates/unions.tmpl
@@ -1,0 +1,49 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- define "unions"}} {{/*gotype: github.com/andreychh/tgen/rendering/python.GenerationContext*/}}
+{{- template "header" .}}
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+from .objects import *
+
+{{- range .Spec.DiscriminatedUnions | discriminated_unions}} {{/*gotype: github.com/andreychh/tgen/rendering/python.DiscriminatedUnion*/}}
+
+{{template "discriminated_union" .}}
+{{- end}}
+
+ChatID = ID | Username
+
+MaybeMessage = Message | Literal[True]
+
+InputFile = FileID | Upload
+
+ReplyMarkup = (
+        InlineKeyboardMarkup
+        | ReplyKeyboardMarkup
+        | ReplyKeyboardRemove
+        | ForceReply
+)
+
+InputMediaGroup = (
+        InputMediaAudio
+        | InputMediaDocument
+        | InputMediaPhoto
+        | InputMediaVideo
+)
+
+InputMessageContent = (
+        InputTextMessageContent
+        | InputLocationMessageContent
+        | InputVenueMessageContent
+        | InputContactMessageContent
+        | InputInvoiceMessageContent
+)
+
+MaybeInaccessibleMessage = InaccessibleMessage | Message
+{{- end}}

--- a/rendering/python/variants.go
+++ b/rendering/python/variants.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package python
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/andreychh/tgen/model/explicit"
+)
+
+type Variants struct {
+	inner iter.Seq[explicit.DiscriminatedObject]
+}
+
+func NewVariants(s iter.Seq[explicit.DiscriminatedObject]) Variants {
+	return Variants{inner: s}
+}
+
+func (v Variants) AsString() (string, error) {
+	var names []string
+	for o := range v.inner {
+		name, err := NewClassName(o.Name()).AsString()
+		if err != nil {
+			return "", fmt.Errorf("variant name: %w", err)
+		}
+		names = append(names, name)
+	}
+	return strings.Join(names, " | "), nil
+}


### PR DESCRIPTION
This PR adds generation of `unions.py` and `__init__.py` to the Python target. `unions.py` emits discriminated unions as `Annotated[..., Field(discriminator=...)]` and overlay types (`ChatID`, `InputFile`, `MaybeInaccessibleMessage`, etc.) as hardcoded definitions, mirroring the approach used in `unions.tmpl` for Go.

`__init__.py` calls `model_rebuild(_types_namespace=...)` after importing both modules, which resolves forward references in `objects.py` without introducing a circular import between `objects.py` and `unions.py`.

Closes #141