### PR TITLE
Add `Zero` method to `Type` for zero-value return expressions

### DIFF
--- a/rendering/golang/expr_type.go
+++ b/rendering/golang/expr_type.go
@@ -20,6 +20,18 @@ var primitives = map[string]string{
 	"True":    "bool",
 }
 
+//nolint:gochecknoglobals // immutable lookup table, not mutable global state
+var zeros = map[string]string{
+	"Integer": "0",
+	"Int":     "0",
+	"Float":   "0",
+	"String":  `""`,
+	"Boolean": "false",
+	"True":    "false",
+}
+
+const zeroNil = "nil"
+
 type ExprType struct {
 	typ model.Type
 }
@@ -87,6 +99,35 @@ func (t ExprType) AsString() (string, error) {
 		return "", fmt.Errorf("getting type expr: %w", err)
 	}
 	return t.render(expr)
+}
+
+func (t ExprType) Zero() (string, error) {
+	depth, err := t.Depth()
+	if err != nil {
+		return "", err
+	}
+	if depth > 0 {
+		return zeroNil, nil
+	}
+	isUnion, err := t.IsUnion()
+	if err != nil {
+		return "", err
+	}
+	if isUnion {
+		return zeroNil, nil
+	}
+	name, err := t.Name()
+	if err != nil {
+		return "", err
+	}
+	if zero, ok := zeros[name]; ok {
+		return zero, nil
+	}
+	formatted, err := NewStringName(name).AsString()
+	if err != nil {
+		return "", err
+	}
+	return formatted + "{}", nil
 }
 
 func (t ExprType) render(expr types.Expression) (string, error) {

--- a/rendering/golang/optional_type.go
+++ b/rendering/golang/optional_type.go
@@ -26,6 +26,17 @@ func (t OptionalType) Depth() (int, error) { return t.inner.Depth() }
 
 func (t OptionalType) Name() (string, error) { return t.inner.Name() }
 
+func (t OptionalType) Zero() (string, error) {
+	opt, err := t.opt.AsBool()
+	if err != nil {
+		return "", fmt.Errorf("getting field optionality: %w", err)
+	}
+	if opt {
+		return zeroNil, nil
+	}
+	return t.inner.Zero()
+}
+
 func (t OptionalType) AsString() (string, error) {
 	str, err := t.inner.AsString()
 	if err != nil {

--- a/rendering/golang/templates/method.tmpl
+++ b/rendering/golang/templates/method.tmpl
@@ -18,13 +18,13 @@ func (m {{$name}}Method) Call(ctx context.Context, conn Connection) ({{$ret.AsSt
 {{- if and $isUnion (eq $depth 1)}}
 	var resp []json.RawMessage
 	if err := conn.Do(ctx, Method{{$name}}, m, &resp); err != nil {
-		return nil, fmt.Errorf("%s: %w", Method{{$name}}, err)
+		return {{.ReturnType.Zero}}, fmt.Errorf("%s: %w", Method{{$name}}, err)
 	}
 	result := make([]{{$ret.Name}}, len(resp))
 	for i, r := range resp {
 		u, err := unmarshal{{$ret.Name}}(r)
 		if err != nil {
-			return nil, err
+			return {{.ReturnType.Zero}}, err
 		}
 		result[i] = u
 	}
@@ -32,17 +32,17 @@ func (m {{$name}}Method) Call(ctx context.Context, conn Connection) ({{$ret.AsSt
 {{- else if $isUnion}}
 	var resp json.RawMessage
 	if err := conn.Do(ctx, Method{{$name}}, m, &resp); err != nil {
-		return nil, fmt.Errorf("%s: %w", Method{{$name}}, err)
+		return {{.ReturnType.Zero}}, fmt.Errorf("%s: %w", Method{{$name}}, err)
 	}
 	result, err := unmarshal{{$ret.Name}}(resp)
 	if err != nil {
-		return nil, err
+		return {{.ReturnType.Zero}}, err
 	}
 	return result, nil
 {{- else}}
 	var resp {{$ret.AsString}}
 	if err := conn.Do(ctx, Method{{$name}}, m, &resp); err != nil {
-		return resp, fmt.Errorf("%s: %w", Method{{$name}}, err)
+		return {{.ReturnType.Zero}}, fmt.Errorf("%s: %w", Method{{$name}}, err)
 	}
 	return resp, nil
 {{- end}}

--- a/rendering/golang/type.go
+++ b/rendering/golang/type.go
@@ -9,4 +9,5 @@ type Type interface {
 	Depth() (int, error)
 	Name() (string, error)
 	AsString() (string, error)
+	Zero() (string, error)
 }


### PR DESCRIPTION
This PR adds a `Zero() (string, error)` method to the `Type` interface and implements it in `ExprType` and `OptionalType`. The template `method.tmpl` uses it to emit typed zero-value literals in error returns instead of hardcoded `nil` or a sentinel variable.

`OptionalType.Zero` returns `"nil"` whenever the field is optional — regardless of depth or union status — because all three optional cases (pointer, slice, interface) share the same zero literal.

Part of #150