### PR TITLE
Add typed `Error` for Telegram API failures in Go and Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -130,6 +131,10 @@ func main() {
 
 	bot, err := api.GetMeMethod{}.Call(ctx, conn)
 	if err != nil {
+		// api.Error carries the numeric code, description, and optional ResponseParameters.
+		if tgErr, ok := errors.AsType[*api.Error](err); ok {
+			log.Fatalf("telegram %d: %s\n", tgErr.Code, tgErr.Description)
+		}
 		log.Fatalln(err)
 	}
 
@@ -250,6 +255,7 @@ from api import (
     ReactionTypeEmoji,
     SendPhotoMethod,
     SetMessageReactionMethod,
+    Error,
     Upload,
 )
 
@@ -260,7 +266,11 @@ CHAT_ID = -1001122334455
 def main():
     conn = HTTPConnection(httpx.Client(timeout=30), TOKEN)
 
-    bot = GetMeMethod().call(conn)
+    try:
+        bot = GetMeMethod().call(conn)
+    except Error as e:
+        # Error carries the numeric code, description, and optional ResponseParameters.
+        sys.exit(f"telegram {e.code}: {e.description}")
 
     # ChatID accepts a numeric ID or a channel username interchangeably:
     # chat = Username("@mychannel")
@@ -284,7 +294,7 @@ def main():
             reply_markup=InlineKeyboardMarkup(
                 inline_keyboard=[[
                     InlineKeyboardButton(
-                        text="What's new →",
+                        text="What's new",
                         url="https://github.com/you/proj/releases",
                     )
                 ]]
@@ -339,10 +349,10 @@ def test_send_message():
 
 def test_send_message_failure():
     conn = FakeConnection({
-        Method.SendMessage: TelegramError("unauthorized"),
+        Method.SendMessage: Error(401, "Unauthorized"),
     })
 
-    with pytest.raises(TelegramError, match="unauthorized"):
+    with pytest.raises(Error, match="Unauthorized"):
         SendMessageMethod(
             chat_id=ID(-1001122334455),
             text="Hello from tgen!",

--- a/targets/golang/templates/client.tmpl
+++ b/targets/golang/templates/client.tmpl
@@ -62,11 +62,15 @@ func (c HTTPConnection) Do(
 		return fmt.Errorf("decoding envelope: %w", err)
 	}
 	if !envelope.Ok {
+		code := 0
+		if envelope.ErrorCode != nil {
+			code = *envelope.ErrorCode
+		}
 		desc := "<no description>"
 		if envelope.Description != nil {
 			desc = *envelope.Description
 		}
-		return fmt.Errorf("telegram error: %s", desc)
+		return &Error{Code: code, Description: desc, Parameters: envelope.Parameters}
 	}
 	if err = json.Unmarshal(envelope.Result, response); err != nil {
 		return fmt.Errorf("decoding result: %w", err)
@@ -76,6 +80,27 @@ func (c HTTPConnection) Do(
 
 func (c HTTPConnection) url(method Method) string {
 	return fmt.Sprintf("https://api.telegram.org/bot%s/%s", c.token, method)
+}
+
+// Envelope represents the standard Telegram Bot API JSON response envelope.
+type Envelope struct {
+	Ok          bool                `json:"ok"`
+	Result      json.RawMessage     `json:"result,omitempty"`
+	ErrorCode   *int                `json:"error_code,omitempty"`
+	Description *string             `json:"description,omitempty"`
+	Parameters  *ResponseParameters `json:"parameters,omitempty"`
+}
+
+// Error represents a failure response from the Telegram Bot API.
+type Error struct {
+	Code        int
+	Description string
+	Parameters  *ResponseParameters
+}
+
+// Error returns a string combining the error code and description.
+func (e *Error) Error() string {
+	return fmt.Sprintf("telegram %d: %s", e.Code, e.Description)
 }
 
 // Response represents the outcome of a FakeConnection call — either a value or

--- a/targets/golang/templates/objects.tmpl
+++ b/targets/golang/templates/objects.tmpl
@@ -16,15 +16,6 @@ import (
 {{- template "object" .}}
 {{- end}}
 
-// Envelope represents the standard Telegram Bot API JSON response envelope.
-type Envelope struct {
-	Ok          bool                `json:"ok"`
-	Result      json.RawMessage     `json:"result,omitempty"`
-	ErrorCode   *int                `json:"error_code,omitempty"`
-	Description *string             `json:"description,omitempty"`
-	Parameters  *ResponseParameters `json:"parameters,omitempty"`
-}
-
 // ID represents a numeric Telegram chat or user identifier.
 type ID int64
 

--- a/targets/python/templates/async_client.tmpl
+++ b/targets/python/templates/async_client.tmpl
@@ -13,6 +13,7 @@ from pydantic import TypeAdapter
 
 from ..client import (
     BoolPart,
+    Envelope,
     FloatPart,
     IntPart,
     JSONPayload,
@@ -23,7 +24,7 @@ from ..client import (
     Response,
     StrPart,
     T,
-    TelegramError,
+    Error,
 )
 from ..method import Method
 
@@ -41,10 +42,10 @@ class HTTPConnection:
         req = payload.request("POST", f"https://api.telegram.org/bot{self._token}/{method.value}")
         resp = await self._client.send(req)
         resp.raise_for_status()
-        data = resp.json()
-        if not data["ok"]:
-            raise TelegramError(data.get("description") or "<no description>")
-        return adapter.validate_python(data["result"])
+        envelope = Envelope.model_validate(resp.json())
+        if not envelope.ok:
+            raise Error(envelope.error_code, envelope.description, envelope.parameters)
+        return adapter.validate_python(envelope.result)
 
 
 class FakeConnection:

--- a/targets/python/templates/client.tmpl
+++ b/targets/python/templates/client.tmpl
@@ -13,6 +13,7 @@ import httpx
 from pydantic import BaseModel, TypeAdapter
 
 from .method import Method
+from .types import ResponseParameters
 
 class Payload(Protocol):
     def request(self, method: str, url: str) -> httpx.Request: ...
@@ -93,8 +94,20 @@ class Connection(Protocol):
     def do(self, method: Method, payload: Payload, adapter: TypeAdapter[T]) -> T: ...
 
 
-class TelegramError(Exception):
-    pass
+class Envelope(BaseModel):
+    ok: bool
+    result: Any = None
+    error_code: int = 0
+    description: str = "<no description>"
+    parameters: ResponseParameters | None = None
+
+
+class Error(Exception):
+    def __init__(self, code: int, description: str, parameters: ResponseParameters | None = None) -> None:
+        super().__init__(description)
+        self.code = code
+        self.description = description
+        self.parameters = parameters
 
 
 class HTTPConnection:
@@ -106,10 +119,10 @@ class HTTPConnection:
         req = payload.request("POST", f"https://api.telegram.org/bot{self._token}/{method.value}")
         resp = self._client.send(req)
         resp.raise_for_status()
-        data = resp.json()
-        if not data["ok"]:
-            raise TelegramError(data.get("description") or "<no description>")
-        return adapter.validate_python(data["result"])
+        envelope = Envelope.model_validate(resp.json())
+        if not envelope.ok:
+            raise Error(envelope.error_code, envelope.description, envelope.parameters)
+        return adapter.validate_python(envelope.result)
 
 
 type Response = Any | Exception


### PR DESCRIPTION
This PR introduces a typed `Error` type in both targets that captures `error_code`, `description`, and `parameters` from the Telegram response envelope, replacing the plain untyped error that discarded all structured fields. In Go `*Error` implements the `error` interface and is compatible with `errors.As` and `errors.AsType`; in Python `Error` extends `Exception` and is catchable with a standard `except` clause.

`Envelope` is defined in `client.tmpl` for both targets rather than `objects.tmpl` / `types.tmpl`, since it is transport infrastructure rather than a spec-derived domain type.

Closes #146