### PR TITLE
Add `DiscriminatedObjects()` to `explicit.Specification`

### DIFF
--- a/model/explicit/explicit.go
+++ b/model/explicit/explicit.go
@@ -17,6 +17,7 @@ import (
 type Specification interface {
 	Objects() iter.Seq[Object]
 	Methods() iter.Seq[Method]
+	DiscriminatedObjects() iter.Seq[DiscriminatedObject]
 	DiscriminatedUnions() iter.Seq[DiscriminatedUnion]
 	Release() Release
 }

--- a/model/explicit/gq/discriminator_value.go
+++ b/model/explicit/gq/discriminator_value.go
@@ -11,7 +11,7 @@ import (
 )
 
 var discriminatorValueRegex = regexp.MustCompile(
-	"always \u201c([^\u201d]+)\u201d|must be ([a-z][a-z0-9_]*)\\s*$",
+	"[Aa]lways (?:\u201c([^\u201d]+)\u201d|(\\d+)\\.)|must be ([a-z][a-z0-9_]*)\\s*$",
 )
 
 // DiscriminatorValue represents the fixed value of a discriminator field,
@@ -26,14 +26,16 @@ func NewDiscriminatorValue(td gq.Selection) DiscriminatorValue {
 }
 
 // AsString returns the discriminator value extracted from the description.
-// Returns an error if no always-quoted or must-be value is found.
+// Returns an error if no always-quoted, always-numeric, or must-be value is found.
 func (v DiscriminatorValue) AsString() (string, error) {
 	match := discriminatorValueRegex.FindStringSubmatch(v.td.Text())
 	if match == nil {
 		return "", errors.New("no discriminator value in description")
 	}
-	if match[1] != "" {
-		return match[1], nil
+	for _, m := range match[1:] {
+		if m != "" {
+			return m, nil
+		}
 	}
-	return match[2], nil
+	return "", errors.New("no discriminator value in description")
 }

--- a/model/explicit/gq/specification.go
+++ b/model/explicit/gq/specification.go
@@ -56,6 +56,22 @@ func (s Specification) Methods() iter.Seq[explicit.Method] {
 	}
 }
 
+func (s Specification) DiscriminatedObjects() iter.Seq[explicit.DiscriminatedObject] {
+	return func(yield func(explicit.DiscriminatedObject) bool) {
+		seq := s.root.
+			Find("div#dev_page_content h4").
+			FilterFunc(func(h4 gq.Selection) bool {
+				return NewHeader(s.root, h4).Kind() == DefinitionKindDiscriminatedObject
+			}).
+			All()
+		for h4 := range seq {
+			if !yield(NewDiscriminatedObject(s.root, h4)) {
+				break
+			}
+		}
+	}
+}
+
 func (s Specification) DiscriminatedUnions() iter.Seq[explicit.DiscriminatedUnion] {
 	return func(yield func(explicit.DiscriminatedUnion) bool) {
 		seq := s.root.

--- a/model/explicit/overlays/specification.go
+++ b/model/explicit/overlays/specification.go
@@ -56,15 +56,15 @@ func (s Specification) Methods() iter.Seq[explicit.Method] {
 
 func (s Specification) DiscriminatedObjects() iter.Seq[explicit.DiscriminatedObject] {
 	return func(yield func(explicit.DiscriminatedObject) bool) {
-		for v := range s.inner.DiscriminatedObjects() {
-			name, _ := v.Name().AsString()
+		for obj := range s.inner.DiscriminatedObjects() {
+			name, _ := obj.Name().AsString()
 			// InaccessibleMessage uses an integer discriminator (date == 0),
 			// which the current string-only discriminator system cannot represent.
 			// It is hardcoded in the template until typed discriminators are supported.
 			if name == "InaccessibleMessage" {
 				continue
 			}
-			if !yield(NewDiscriminatedObject(v, s.overlay)) {
+			if !yield(NewDiscriminatedObject(obj, s.overlay)) {
 				break
 			}
 		}

--- a/model/explicit/overlays/specification.go
+++ b/model/explicit/overlays/specification.go
@@ -54,6 +54,23 @@ func (s Specification) Methods() iter.Seq[explicit.Method] {
 	}
 }
 
+func (s Specification) DiscriminatedObjects() iter.Seq[explicit.DiscriminatedObject] {
+	return func(yield func(explicit.DiscriminatedObject) bool) {
+		for v := range s.inner.DiscriminatedObjects() {
+			name, _ := v.Name().AsString()
+			// InaccessibleMessage uses an integer discriminator (date == 0),
+			// which the current string-only discriminator system cannot represent.
+			// It is hardcoded in the template until typed discriminators are supported.
+			if name == "InaccessibleMessage" {
+				continue
+			}
+			if !yield(NewDiscriminatedObject(v, s.overlay)) {
+				break
+			}
+		}
+	}
+}
+
 func (s Specification) DiscriminatedUnions() iter.Seq[explicit.DiscriminatedUnion] {
 	return iters.NewMappedSeq(
 		s.inner.DiscriminatedUnions(),

--- a/targets/golang/specification.go
+++ b/targets/golang/specification.go
@@ -23,15 +23,7 @@ func (s Specification) Objects() iter.Seq[Object] {
 }
 
 func (s Specification) DiscriminatedObjects() iter.Seq[DiscriminatedObject] {
-	return func(yield func(DiscriminatedObject) bool) {
-		for u := range s.inner.DiscriminatedUnions() {
-			for v := range u.Variants() {
-				if !yield(NewDiscriminatedObject(v)) {
-					return
-				}
-			}
-		}
-	}
+	return iters.NewMappedSeq(s.inner.DiscriminatedObjects(), NewDiscriminatedObject)
 }
 
 func (s Specification) Methods() iter.Seq[Method] {

--- a/targets/python/specification.go
+++ b/targets/python/specification.go
@@ -23,15 +23,7 @@ func (s Specification) Objects() iter.Seq[Object] {
 }
 
 func (s Specification) DiscriminatedObjects() iter.Seq[DiscriminatedObject] {
-	return func(yield func(DiscriminatedObject) bool) {
-		for u := range s.inner.DiscriminatedUnions() {
-			for v := range u.Variants() {
-				if !yield(NewDiscriminatedObject(v)) {
-					return
-				}
-			}
-		}
-	}
+	return iters.NewMappedSeq(s.inner.DiscriminatedObjects(), NewDiscriminatedObject)
 }
 
 func (s Specification) DiscriminatedUnions() iter.Seq[DiscriminatedUnion] {


### PR DESCRIPTION
This PR adds `DiscriminatedObjects() iter.Seq[DiscriminatedObject]` to `explicit.Specification` and implements it across `gq`, `overlays`, and both rendering targets, allowing `targets/golang` and `targets/python` to delegate directly instead of flattening `DiscriminatedUnions() → Variants()` themselves.

The `gq` implementation uses a direct HTML selector via `DefinitionKindDiscriminatedObject`, which revealed two pre-existing gaps: `discriminatorValueRegex` didn't cover numeric discriminator values (now fixed to match `fieldRowDiscriminatorRegex`), and `InaccessibleMessage` — whose discriminator is an integer `0` — is excluded in `overlays` with a comment until typed discriminators are supported.

Closes #168