### PR TITLE
Add FormJSON and SlicePart for transitive multipart encoding

### DIFF
--- a/targets/golang/discriminated_object.go
+++ b/targets/golang/discriminated_object.go
@@ -28,6 +28,19 @@ func (o DiscriminatedObject) Fields() DiscriminatedObjectFields {
 	return NewDiscriminatedObjectFields(o.inner.Fields())
 }
 
+func (o DiscriminatedObject) HasInputFile() (bool, error) {
+	for f := range o.Fields().Free() {
+		ok, err := f.IsInputFile()
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (o DiscriminatedObject) Unions() Unions {
 	return Unions{inner: iters.NewMappedSeq(o.inner.Fields().Free(), NewField)}
 }

--- a/targets/golang/expr_type.go
+++ b/targets/golang/expr_type.go
@@ -125,12 +125,15 @@ func (t ExprType) Part() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if depth > 0 {
-		return "NewJSONPart(%s)", nil
-	}
 	name, err := t.Name()
 	if err != nil {
 		return "", err
+	}
+	if depth > 0 {
+		if _, ok := parts[name]; ok {
+			return "NewJSONPart(%s)", nil
+		}
+		return "NewSlicePart(%s)", nil
 	}
 	if part, ok := parts[name]; ok {
 		return part + "(%s)", nil

--- a/targets/golang/field.go
+++ b/targets/golang/field.go
@@ -41,6 +41,14 @@ func (f Field) Doc() GoDoc {
 	return NewGoDoc(f.inner.Description())
 }
 
+func (f Field) IsInputFile() (bool, error) {
+	name, err := f.Type().Name()
+	if err != nil {
+		return false, err
+	}
+	return name == "InputFile", nil
+}
+
 func (f Field) Part() (string, error) {
 	part, err := f.Type().Part()
 	if err != nil {

--- a/targets/golang/method.go
+++ b/targets/golang/method.go
@@ -33,13 +33,3 @@ func (m Method) ReturnType() Type {
 func (m Method) Fields() iter.Seq[Field] {
 	return iters.NewMappedSeq(m.inner.Fields(), NewField)
 }
-
-func (m Method) IsMultipart() bool {
-	return iters.IsAny(m.inner.Fields(), func(f explicit.Field) bool {
-		name, err := NewExprType(f.Type()).Name()
-		if err != nil {
-			return false
-		}
-		return name == "InputFile"
-	})
-}

--- a/targets/golang/object.go
+++ b/targets/golang/object.go
@@ -30,6 +30,19 @@ func (o Object) Fields() iter.Seq[Field] {
 	return iters.NewMappedSeq(o.inner.Fields(), NewField)
 }
 
+func (o Object) HasInputFile() (bool, error) {
+	for f := range o.Fields() {
+		ok, err := f.IsInputFile()
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (o Object) Unions() Unions {
 	return Unions{inner: o.Fields()}
 }

--- a/targets/golang/templates/client.tmpl
+++ b/targets/golang/templates/client.tmpl
@@ -38,8 +38,8 @@ func NewHTTPConnection(client *http.Client, token string) HTTPConnection {
 	return HTTPConnection{client: client, token: token}
 }
 
-// Do marshals request as JSON, sends a POST to the Telegram API, and decodes
-// the result into response. It returns an error if the request cannot be built,
+// Do sends a multipart/form-data POST to the Telegram API and decodes the
+// result into response. It returns an error if the request cannot be built,
 // the transport fails, the API reports a failure, or the result cannot be
 // decoded.
 func (c HTTPConnection) Do(
@@ -159,46 +159,40 @@ func (c FakeConnection) Do(_ context.Context, method Method, _ Payload, response
 	return nil
 }
 
+// Payload produces an HTTP request from accumulated method fields.
 type Payload interface {
 	Request(ctx context.Context, method, url string) (*http.Request, error)
 }
 
-type JSONPayload struct {
-	value any
-}
-
-func NewJSONPayload(value any) JSONPayload {
-	return JSONPayload{value: value}
-}
-
-func (p JSONPayload) Request(ctx context.Context, method, url string) (*http.Request, error) {
-	data, err := json.Marshal(p.value)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(data))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return req, nil
-}
-
+// MultipartPayload builds a multipart/form-data request body.
 type MultipartPayload struct {
-	buffer *bytes.Buffer
-	writer *multipart.Writer
+	buffer   *bytes.Buffer
+	writer   *multipart.Writer
+	counter  int
+	modified bool
 }
 
+// NewMultipartPayload creates an empty MultipartPayload.
 func NewMultipartPayload() *MultipartPayload {
 	b := &bytes.Buffer{}
 	return &MultipartPayload{buffer: b, writer: multipart.NewWriter(b)}
 }
 
+func (m *MultipartPayload) AttachKey() string {
+	key := fmt.Sprintf("attachment_%d", m.counter)
+	m.counter++
+	return key
+}
+
+// Text adds a plain-text form part.
 func (m *MultipartPayload) Text(key, value string) error {
+	m.modified = true
 	return m.writer.WriteField(key, value)
 }
 
+// File adds a binary file form part.
 func (m *MultipartPayload) File(key, name string, reader io.Reader) error {
+	m.modified = true
 	part, err := m.writer.CreateFormFile(key, name)
 	if err != nil {
 		return fmt.Errorf("creating file part: %w", err)
@@ -213,6 +207,9 @@ func (m *MultipartPayload) Request(ctx context.Context, method, url string) (*ht
 	if err := m.writer.Close(); err != nil {
 		return nil, fmt.Errorf("closing multipart: %w", err)
 	}
+	if !m.modified {
+		return http.NewRequestWithContext(ctx, method, url, http.NoBody)
+	}
 	req, err := http.NewRequestWithContext(ctx, method, url, m.buffer)
 	if err != nil {
 		return nil, err
@@ -221,8 +218,14 @@ func (m *MultipartPayload) Request(ctx context.Context, method, url string) (*ht
 	return req, nil
 }
 
+// Part writes a single method field into a Form.
 type Part interface {
 	Write(p *MultipartPayload, key string) error
+}
+
+// FormJSON encodes a value as JSON, resolving any InputFile references into p.
+type FormJSON interface {
+	JSON(p *MultipartPayload) ([]byte, error)
 }
 
 type StringPart struct {
@@ -283,6 +286,30 @@ func NewJSONPart[T any](v T) JSONPart[T] {
 
 func (j JSONPart[T]) Write(p *MultipartPayload, key string) error {
 	data, err := json.Marshal(j.v)
+	if err != nil {
+		return err
+	}
+	return p.Text(key, string(data))
+}
+
+type SlicePart[T FormJSON] struct {
+	v []T
+}
+
+func NewSlicePart[T FormJSON](v []T) SlicePart[T] {
+	return SlicePart[T]{v: v}
+}
+
+func (s SlicePart[T]) Write(p *MultipartPayload, key string) error {
+	parts := make([]json.RawMessage, len(s.v))
+	for i, el := range s.v {
+		data, err := el.JSON(p)
+		if err != nil {
+			return err
+		}
+		parts[i] = data
+	}
+	data, err := json.Marshal(parts)
 	if err != nil {
 		return err
 	}

--- a/targets/golang/templates/discriminated_object.tmpl
+++ b/targets/golang/templates/discriminated_object.tmpl
@@ -18,8 +18,63 @@ func (v {{.Name.AsString}}) MarshalJSON() ([]byte, error) {
     }{"{{.Fields.Discriminator.Value.AsString}}", Alias(v)})
 }
 
+{{- if .HasInputFile}}
+func (o {{.Name.AsString}}) JSON(p *MultipartPayload) ([]byte, error) {
+    type Alias {{.Name.AsString}}
+{{- range .Fields.Free | fields}}
+{{- if .IsInputFile}}
+{{- if .Optional}}
+    var {{.Key}} *string
+    if o.{{.Name.AsString}} != nil {
+        ref, err := o.{{.Name.AsString}}.Attach(p)
+        if err != nil {
+            return nil, err
+        }
+        {{.Key}} = &ref
+    }
+{{- else}}
+    {{.Key}}, err := o.{{.Name.AsString}}.Attach(p)
+    if err != nil {
+        return nil, err
+    }
+{{- end}}
+{{- end}}
+{{- end}}
+    return json.Marshal(struct {
+        Key string `json:"{{.Fields.Discriminator.Key.AsString}}"`
+{{- range .Fields.Free | fields}}
+{{- if .IsInputFile}}
+{{- if .Optional}}
+        {{.Name.AsString}} *string {{.Tag.AsString}}
+{{- else}}
+        {{.Name.AsString}} string {{.Tag.AsString}}
+{{- end}}
+{{- end}}
+{{- end}}
+        Alias
+    }{
+        Key: "{{.Fields.Discriminator.Value.AsString}}",
+{{- range .Fields.Free | fields}}
+{{- if .IsInputFile}}
+        {{.Name.AsString}}: {{.Key}},
+{{- end}}
+{{- end}}
+        Alias: Alias(o),
+    })
+}
+{{- else}}
+
+func (o {{.Name.AsString}}) JSON(_ *MultipartPayload) ([]byte, error) {
+    return json.Marshal(o)
+}
+{{- end}}
+
 func (o {{.Name.AsString}}) Write(p *MultipartPayload, key string) error {
-    return NewJSONPart(o).Write(p, key)
+    data, err := o.JSON(p)
+    if err != nil {
+        return err
+    }
+    return p.Text(key, string(data))
 }
 
 {{- template "unmarshal_object" .}}

--- a/targets/golang/templates/discriminated_union.tmpl
+++ b/targets/golang/templates/discriminated_union.tmpl
@@ -5,7 +5,7 @@
 {{- $name := .Name.AsString}}
 {{.Doc.AsString}}
 //sumtype:decl
-type {{$name}} interface{ Part; sealed{{$name}}() }
+type {{$name}} interface{ Part; FormJSON; sealed{{$name}}() }
 {{range .Variants | discriminated_variants}}
 func (v {{.Name.AsString}}) sealed{{$name}}() {}
 {{- end}}

--- a/targets/golang/templates/method.tmpl
+++ b/targets/golang/templates/method.tmpl
@@ -14,57 +14,18 @@ type {{$name}}Method struct {
 {{- end}}
 }
 
-{{- if not .IsMultipart}}
-func (m {{$name}}Method) Call(ctx context.Context, conn Connection) ({{$ret.AsString}}, error) {
-	payload := NewJSONPayload(m)
-{{- if and $isUnion (eq $depth 1)}}
-	var resp []json.RawMessage
-{{- else if $isUnion}}
-	var resp json.RawMessage
-{{- else}}
-	var resp {{$ret.AsString}}
-{{- end}}
-	err := conn.Do(ctx, Method{{$name}}, payload, &resp)
-	if err != nil {
-		return {{$ret.Zero}}, fmt.Errorf("%s: %w", Method{{$name}}, err)
-	}
-{{- if and $isUnion (eq $depth 1)}}
-	result := make([]{{$ret.Name}}, len(resp))
-	for i, r := range resp {
-		u, err := unmarshal{{$ret.Name}}(r)
-		if err != nil {
-			return {{$ret.Zero}}, err
-		}
-		result[i] = u
-	}
-	return result, nil
-{{- else if $isUnion}}
-	result, err := unmarshal{{$ret.Name}}(resp)
-	if err != nil {
-		return {{$ret.Zero}}, err
-	}
-	return result, nil
-{{- else}}
-	return resp, nil
-{{- end}}
-}
-{{- else}}
 func (m {{$name}}Method) Call(ctx context.Context, conn Connection) ({{$ret.AsString}}, error) {
 	payload := NewMultipartPayload()
 {{- range .Fields | fields}} {{/*gotype: github.com/andreychh/tgen/targets/golang.Field*/}}
-{{- if .Optional }}
+{{- if .Optional}}
 	if m.{{.Name.AsString}} != nil {
-		err := {{.Part}}.Write(payload, "{{.Key}}");
-		if err != nil {
+		if err := {{.Part}}.Write(payload, "{{.Key}}"); err != nil {
 			return {{$ret.Zero}}, err
 		}
 	}
 {{- else}}
-	{
-		err := {{.Part}}.Write(payload, "{{.Key}}");
-		if err != nil {
-			return {{$ret.Zero}}, err
-		}
+	if err := {{.Part}}.Write(payload, "{{.Key}}"); err != nil {
+		return {{$ret.Zero}}, err
 	}
 {{- end}}
 {{- end}}
@@ -99,5 +60,4 @@ func (m {{$name}}Method) Call(ctx context.Context, conn Connection) ({{$ret.AsSt
 	return resp, nil
 {{- end}}
 }
-{{- end}}
 {{- end}}

--- a/targets/golang/templates/object.tmpl
+++ b/targets/golang/templates/object.tmpl
@@ -12,7 +12,60 @@ type {{.Name.AsString}} struct {
 
 {{- template "unmarshal_object" .}}
 
+{{- if .HasInputFile}}
+func (o {{.Name.AsString}}) JSON(p *MultipartPayload) ([]byte, error) {
+	type Alias {{.Name.AsString}}
+{{- range .Fields | fields}}
+{{- if .IsInputFile}}
+{{- if .Optional}}
+	var {{.Key}} *string
+	if o.{{.Name.AsString}} != nil {
+		ref, err := o.{{.Name.AsString}}.Attach(p)
+		if err != nil {
+			return nil, err
+		}
+		{{.Key}} = &ref
+	}
+{{- else}}
+	{{.Key}}, err := o.{{.Name.AsString}}.Attach(p)
+	if err != nil {
+		return nil, err
+	}
+{{- end}}
+{{- end}}
+{{- end}}
+	return json.Marshal(struct {
+{{- range .Fields | fields}}
+{{- if .IsInputFile}}
+{{- if .Optional}}
+		{{.Name.AsString}} *string {{.Tag.AsString}}
+{{- else}}
+		{{.Name.AsString}} string {{.Tag.AsString}}
+{{- end}}
+{{- end}}
+{{- end}}
+		Alias
+	}{
+{{- range .Fields | fields}}
+{{- if .IsInputFile}}
+		{{.Name.AsString}}: {{.Key}},
+{{- end}}
+{{- end}}
+		Alias: Alias(o),
+	})
+}
+{{- else}}
+
+func (o {{.Name.AsString}}) JSON(_ *MultipartPayload) ([]byte, error) {
+	return json.Marshal(o)
+}
+{{- end}}
+
 func (o {{.Name.AsString}}) Write(p *MultipartPayload, key string) error {
-	return NewJSONPart(o).Write(p, key)
+	data, err := o.JSON(p)
+	if err != nil {
+		return err
+	}
+	return p.Text(key, string(data))
 }
 {{- end}}

--- a/targets/golang/templates/objects.tmpl
+++ b/targets/golang/templates/objects.tmpl
@@ -40,6 +40,10 @@ func (i FileID) Write(p *MultipartPayload, key string) error {
 	return NewStringPart(i).Write(p, key)
 }
 
+func (i FileID) Attach(_ *MultipartPayload) (string, error) {
+	return string(i), nil
+}
+
 // Upload represents a file to be uploaded by providing its name and reader.
 type Upload struct {
 	Name   string
@@ -48,6 +52,14 @@ type Upload struct {
 
 func (u Upload) Write(p *MultipartPayload, key string) error {
 	return p.File(key, u.Name, u.Reader)
+}
+
+func (u Upload) Attach(p *MultipartPayload) (string, error) {
+	key := p.AttachKey()
+	if err := u.Write(p, key); err != nil {
+		return "", err
+	}
+	return "attach://" + key, nil
 }
 
 {{- range .Spec.DiscriminatedObjects | discriminated_objects}} {{/*gotype: github.com/andreychh/tgen/targets/golang.DiscriminatedObject*/}}

--- a/targets/golang/templates/unions.tmpl
+++ b/targets/golang/templates/unions.tmpl
@@ -59,7 +59,11 @@ func unmarshalChatID(data []byte) (ChatID, error) {
 // InputFile represents a file to send, either by file ID or by uploading.
 //
 //sumtype:decl
-type InputFile interface{ Part; sealedInputFile() }
+type InputFile interface {
+    Part
+    Attach(p *MultipartPayload) (string, error)
+    sealedInputFile()
+}
 
 func (v FileID) sealedInputFile() {}
 func (v Upload) sealedInputFile() {}
@@ -71,7 +75,7 @@ func unmarshalInputFile(data []byte) (InputFile, error) {
 // ReplyMarkup represents a reply markup attached to a message.
 //
 //sumtype:decl
-type ReplyMarkup interface{ Part; sealedReplyMarkup() }
+type ReplyMarkup interface{ Part; FormJSON; sealedReplyMarkup() }
 
 func (v InlineKeyboardMarkup) sealedReplyMarkup() {}
 func (v ReplyKeyboardMarkup) sealedReplyMarkup()  {}
@@ -85,7 +89,7 @@ func unmarshalReplyMarkup(data []byte) (ReplyMarkup, error) {
 // InputMediaGroup represents a media element in a media group.
 //
 //sumtype:decl
-type InputMediaGroup interface{ Part; sealedInputMediaGroup() }
+type InputMediaGroup interface{ Part; FormJSON; sealedInputMediaGroup() }
 
 func (v InputMediaAudio) sealedInputMediaGroup()    {}
 func (v InputMediaDocument) sealedInputMediaGroup() {}
@@ -100,7 +104,7 @@ func unmarshalInputMediaGroup(data []byte) (InputMediaGroup, error) {
 // inline query result.
 //
 //sumtype:decl
-type InputMessageContent interface{ Part; sealedInputMessageContent() }
+type InputMessageContent interface{ Part; FormJSON; sealedInputMessageContent() }
 
 func (v InputInvoiceMessageContent) sealedInputMessageContent()  {}
 func (v InputVenueMessageContent) sealedInputMessageContent()    {}


### PR DESCRIPTION
This PR introduces `FormJSON`, `SlicePart`, and `JSON` methods to the Go codegen target, enabling objects that contain `InputFile` fields to resolve `attach://` references before serializing to JSON.

`SlicePart[T FormJSON]` replaces `NewJSONPart` for slices of non-primitive types — `ExprType.Part()` now distinguishes primitive element types (which use `NewJSONPart`) from object types (which use `NewSlicePart`). All discriminated union interfaces gain `FormJSON` so they satisfy the constraint. All methods now always use `MultipartPayload` — the `JSONPayload` path and `IsMultipart` detection have been removed.

Part of #175