### PR TITLE
Add `InputMediaLivePhoto` to `InputMediaGroup` union

### DIFF
--- a/model/explicit/overlays/input_media_group.go
+++ b/model/explicit/overlays/input_media_group.go
@@ -20,6 +20,7 @@ func (o InputMediaGroup) Apply(field explicit.Field) explicit.Field {
 	if !expr.Equals(types.NewArray(types.NewUnion(
 		types.NewNamed("InputMediaAudio", types.KindObject),
 		types.NewNamed("InputMediaDocument", types.KindObject),
+		types.NewNamed("InputMediaLivePhoto", types.KindObject),
 		types.NewNamed("InputMediaPhoto", types.KindObject),
 		types.NewNamed("InputMediaVideo", types.KindObject),
 	))) {

--- a/targets/golang/templates/unions.tmpl
+++ b/targets/golang/templates/unions.tmpl
@@ -93,6 +93,7 @@ type InputMediaGroup interface{ Part; FormJSON; sealedInputMediaGroup() }
 
 func (v InputMediaAudio) sealedInputMediaGroup()    {}
 func (v InputMediaDocument) sealedInputMediaGroup() {}
+func (v InputMediaLivePhoto) sealedInputMediaGroup() {}
 func (v InputMediaPhoto) sealedInputMediaGroup()    {}
 func (v InputMediaVideo) sealedInputMediaGroup()    {}
 

--- a/targets/python/templates/types.tmpl
+++ b/targets/python/templates/types.tmpl
@@ -101,6 +101,7 @@ type ReplyMarkup = (
 type InputMediaGroup = (
         InputMediaAudio
         | InputMediaDocument
+        | InputMediaLivePhoto
         | InputMediaPhoto
         | InputMediaVideo
 )


### PR DESCRIPTION
This PR adds `InputMediaLivePhoto` as a variant of the `InputMediaGroup` union — in the overlay type check, the Go sealed interface, and the Python type alias.

Test stands for the new type will follow in a separate PR.

Closes #180