### PR TITLE
Model method result as Command or Value

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -20,6 +20,9 @@ legacy_version_file = false
 "pipx:reuse" = "6.2.0"
 "pipx:yamllint" = "1.38.0"
 
+# indirect
+"node" = "24.14.0"
+
 [env]
 _.file = ".env"
 GOROOT = ""

--- a/model/ir/method.go
+++ b/model/ir/method.go
@@ -4,6 +4,7 @@
 package ir
 
 import (
+	"fmt"
 	"iter"
 
 	"github.com/andreychh/tgen/model"
@@ -34,12 +35,19 @@ func (m Method) Description() model.Description {
 	return m.inner.Description()
 }
 
-func (m Method) ReturnType() (Type, error) {
-	expr, err := m.inner.ReturnType()
+func (m Method) Result() (Result, error) {
+	result, err := m.inner.Result()
 	if err != nil {
-		return Type{}, err
+		return nil, err
 	}
-	return NewType(expr), nil
+	switch result := result.(type) {
+	case spec.Command:
+		return NewCommand(), nil
+	case spec.Value:
+		return NewValue(NewType(result.Type())), nil
+	default:
+		return nil, fmt.Errorf("narrowing method result: unexpected result type %T", result)
+	}
 }
 
 func (m Method) Fields() iter.Seq[Field] {

--- a/model/ir/result.go
+++ b/model/ir/result.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+// Result represents what a Telegram Bot API method returns: either a Command
+// that only signals success or a Value that carries a resolved return type.
+//
+//sumtype:decl
+type Result interface {
+	isResult()
+}
+
+// Command represents a method result that only signals success.
+type Command struct{}
+
+// NewCommand constructs a Command.
+func NewCommand() Command {
+	return Command{}
+}
+
+func (Command) isResult() {}
+
+// Value represents a method result that carries a resolved return type.
+type Value struct {
+	typ Type
+}
+
+// NewValue constructs a Value from a resolved return type.
+func NewValue(typ Type) Value {
+	return Value{typ: typ}
+}
+
+// Type returns the resolved return type carried by the Value.
+func (v Value) Type() Type {
+	return v.typ
+}
+
+func (Value) isResult() {}

--- a/model/spec/explicit.go
+++ b/model/spec/explicit.go
@@ -34,7 +34,7 @@ type Method interface {
 	Reference() (model.Reference, error)
 	Name() (model.Name, error)
 	Description() model.Description
-	ReturnType() (types.Expression, error)
+	Result() (Result, error)
 	Fields() iter.Seq[Field]
 }
 

--- a/model/spec/gq/method.go
+++ b/model/spec/gq/method.go
@@ -34,8 +34,15 @@ func (m Method) Description() model.Description {
 	return NewDefinitionDescription(m.h4)
 }
 
-func (m Method) ReturnType() (types.Expression, error) {
-	return NewReturnType(m.root, m.h4).Value()
+func (m Method) Result() (spec.Result, error) {
+	expr, err := NewReturnType(m.root, m.h4).Value()
+	if err != nil {
+		return nil, err
+	}
+	if expr.Equals(types.NewNamed("True", types.KindPrimitive)) {
+		return spec.NewCommand(), nil
+	}
+	return spec.NewValue(expr), nil
 }
 
 func (m Method) Fields() iter.Seq[spec.Field] {

--- a/model/spec/gq/method_test.go
+++ b/model/spec/gq/method_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package gq_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/andreychh/tgen/model/spec"
+	"github.com/andreychh/tgen/model/spec/gq"
+	"github.com/andreychh/tgen/model/types"
+)
+
+func TestMethod_Result(t *testing.T) {
+	msg := types.NewNamed("Message", types.KindObject)
+	trueType := types.NewNamed("True", types.KindPrimitive)
+	cases := []struct {
+		name    string
+		desc    string
+		noDesc  bool
+		want    spec.Result
+		wantErr bool
+	}{
+		{
+			name: "classifies a bare True success sentinel as a Command",
+			desc: "Returns True on success.",
+			want: spec.NewCommand(),
+		},
+		{
+			name: "classifies a named return as a Value carrying the expression",
+			desc: "Returns Message on success.",
+			want: spec.NewValue(msg),
+		},
+		{
+			name: "classifies a union containing True as a Value, not a Command",
+			desc: "the Message is returned, otherwise True is returned",
+			want: spec.NewValue(types.NewUnion(msg, trueType)),
+		},
+		{
+			name:    "propagates the error when the return type cannot be extracted",
+			noDesc:  true,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, h4 := returnTypeFixture(tc.desc)
+			if tc.noDesc {
+				root, h4 = returnTypeNoParaFixture()
+			}
+			got, err := gq.NewMethod(root, h4).Result()
+			if tc.wantErr {
+				assert.Error(
+					t,
+					err,
+					"Method.Result must propagate errors from return type extraction",
+				)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				tc.want,
+				got,
+				"Method.Result must classify a bare True as a Command and any other return as a Value",
+			)
+		})
+	}
+}

--- a/model/spec/overlays/maybe_message.go
+++ b/model/spec/overlays/maybe_message.go
@@ -4,6 +4,7 @@
 package overlays
 
 import (
+	"fmt"
 	"iter"
 
 	"github.com/andreychh/tgen/model"
@@ -34,18 +35,25 @@ func (r MaybeMessage) Description() model.Description {
 	return r.inner.Description()
 }
 
-func (r MaybeMessage) ReturnType() (types.Expression, error) {
-	expr, err := r.inner.ReturnType()
+func (r MaybeMessage) Result() (spec.Result, error) {
+	result, err := r.inner.Result()
 	if err != nil {
 		return nil, err
 	}
-	if !expr.Equals(types.NewUnion(
-		types.NewNamed("Message", types.KindObject),
-		types.NewNamed("True", types.KindPrimitive),
-	)) {
-		return expr, nil
+	switch result := result.(type) {
+	case spec.Command:
+		return result, nil
+	case spec.Value:
+		if !result.Type().Equals(types.NewUnion(
+			types.NewNamed("Message", types.KindObject),
+			types.NewNamed("True", types.KindPrimitive),
+		)) {
+			return result, nil
+		}
+		return spec.NewValue(types.NewNamed("MaybeMessage", types.KindUnion)), nil
+	default:
+		return nil, fmt.Errorf("classifying method result: unexpected result type %T", result)
 	}
-	return types.NewNamed("MaybeMessage", types.KindUnion), nil
 }
 
 func (r MaybeMessage) Fields() iter.Seq[spec.Field] {

--- a/model/spec/overlays/maybe_message_test.go
+++ b/model/spec/overlays/maybe_message_test.go
@@ -15,46 +15,52 @@ import (
 	"github.com/andreychh/tgen/model/types"
 )
 
-func TestMaybeMessage_ReturnType(t *testing.T) {
+func TestMaybeMessage_Result(t *testing.T) {
 	message := types.NewNamed("Message", types.KindObject)
 	trueType := types.NewNamed("True", types.KindPrimitive)
+	chat := types.NewNamed("Chat", types.KindObject)
 	cases := []struct {
 		name    string
 		method  spec.Method
-		want    types.Expression
+		want    spec.Result
 		wantErr bool
 	}{
 		{
-			name:   "replaces Message or True union return type with MaybeMessage named type",
-			method: stubMethod{returnType: types.NewUnion(message, trueType)},
-			want:   types.NewNamed("MaybeMessage", types.KindUnion),
+			name:   "replaces a Message or True Value with a MaybeMessage Value",
+			method: stubMethod{result: spec.NewValue(types.NewUnion(message, trueType))},
+			want:   spec.NewValue(types.NewNamed("MaybeMessage", types.KindUnion)),
 		},
 		{
-			name:   "passes through Message return type without replacement",
-			method: stubMethod{returnType: message},
-			want:   message,
+			name:   "passes through a Message Value without replacement",
+			method: stubMethod{result: spec.NewValue(message)},
+			want:   spec.NewValue(message),
 		},
 		{
-			name: "passes through a non-matching union return type without replacement",
+			name: "passes through a non-matching union Value without replacement",
 			method: stubMethod{
-				returnType: types.NewUnion(message, types.NewNamed("Chat", types.KindObject)),
+				result: spec.NewValue(types.NewUnion(message, chat)),
 			},
-			want: types.NewUnion(message, types.NewNamed("Chat", types.KindObject)),
+			want: spec.NewValue(types.NewUnion(message, chat)),
 		},
 		{
-			name:    "propagates error when the inner method's ReturnType returns an error",
-			method:  stubMethod{returnErr: errors.New("no return type")},
+			name:   "passes through a Command without replacement",
+			method: stubMethod{result: spec.NewCommand()},
+			want:   spec.NewCommand(),
+		},
+		{
+			name:    "propagates error when the inner method's Result returns an error",
+			method:  stubMethod{resultErr: errors.New("no result")},
 			wantErr: true,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := overlays.NewMaybeMessage(tc.method).ReturnType()
+			got, err := overlays.NewMaybeMessage(tc.method).Result()
 			if tc.wantErr {
 				assert.Error(
 					t,
 					err,
-					"MaybeMessage.ReturnType must propagate errors from the inner method",
+					"MaybeMessage.Result must propagate errors from the inner method",
 				)
 				return
 			}
@@ -63,7 +69,7 @@ func TestMaybeMessage_ReturnType(t *testing.T) {
 				t,
 				tc.want,
 				got,
-				"MaybeMessage.ReturnType must replace Message|True with MaybeMessage and pass through all other return types",
+				"MaybeMessage.Result must replace a Message|True Value with a MaybeMessage Value and pass through all other results",
 			)
 		})
 	}

--- a/model/spec/overlays/method.go
+++ b/model/spec/overlays/method.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/spec"
-	"github.com/andreychh/tgen/model/types"
 	"github.com/andreychh/tgen/pkg/iters"
 )
 
@@ -36,8 +35,8 @@ func (m Method) Description() model.Description {
 	return m.inner.Description()
 }
 
-func (m Method) ReturnType() (types.Expression, error) {
-	return m.inner.ReturnType()
+func (m Method) Result() (spec.Result, error) {
+	return m.inner.Result()
 }
 
 func (m Method) Fields() iter.Seq[spec.Field] {

--- a/model/spec/overlays/stubs_test.go
+++ b/model/spec/overlays/stubs_test.go
@@ -45,13 +45,13 @@ var (
 )
 
 type stubMethod struct {
-	returnType types.Expression
-	returnErr  error
-	fields     []spec.Field
+	result    spec.Result
+	resultErr error
+	fields    []spec.Field
 }
 
-func (m stubMethod) Reference() (model.Reference, error)   { return "", nil }
-func (m stubMethod) Name() (model.Name, error)             { return "", nil }
-func (m stubMethod) Description() model.Description        { return stubDesc{} }
-func (m stubMethod) ReturnType() (types.Expression, error) { return m.returnType, m.returnErr }
-func (m stubMethod) Fields() iter.Seq[spec.Field]          { return slices.Values(m.fields) }
+func (m stubMethod) Reference() (model.Reference, error) { return "", nil }
+func (m stubMethod) Name() (model.Name, error)           { return "", nil }
+func (m stubMethod) Description() model.Description      { return stubDesc{} }
+func (m stubMethod) Result() (spec.Result, error)        { return m.result, m.resultErr }
+func (m stubMethod) Fields() iter.Seq[spec.Field]        { return slices.Values(m.fields) }

--- a/model/spec/result.go
+++ b/model/spec/result.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package spec
+
+import "github.com/andreychh/tgen/model/types"
+
+// Result represents what a Telegram Bot API method returns: either a Command
+// that only signals success or a Value that carries a typed return expression.
+//
+//sumtype:decl
+type Result interface {
+	isResult()
+}
+
+// Command represents a method result that only signals success.
+type Command struct{}
+
+// NewCommand constructs a Command.
+func NewCommand() Command {
+	return Command{}
+}
+
+func (Command) isResult() {}
+
+// Value represents a method result that carries a typed return expression.
+type Value struct {
+	expr types.Expression
+}
+
+// NewValue constructs a Value from a return type expression.
+func NewValue(expr types.Expression) Value {
+	return Value{expr: expr}
+}
+
+// Type returns the return type expression carried by the Value.
+func (v Value) Type() types.Expression {
+	return v.expr
+}
+
+func (Value) isResult() {}

--- a/targets/golang/method.go
+++ b/targets/golang/method.go
@@ -4,9 +4,11 @@
 package golang
 
 import (
+	"fmt"
 	"iter"
 
 	"github.com/andreychh/tgen/model/ir"
+	"github.com/andreychh/tgen/model/types"
 	"github.com/andreychh/tgen/pkg/iters"
 )
 
@@ -39,11 +41,18 @@ func (m Method) Doc() (string, error) {
 }
 
 func (m Method) ReturnType() (Type, error) {
-	typ, err := m.inner.ReturnType()
+	result, err := m.inner.Result()
 	if err != nil {
 		return Type{}, err
 	}
-	return NewRequiredType(typ), nil
+	switch result := result.(type) {
+	case ir.Command:
+		return NewRequiredType(ir.NewType(types.NewNamed("True", types.KindPrimitive))), nil
+	case ir.Value:
+		return NewRequiredType(result.Type()), nil
+	default:
+		return Type{}, fmt.Errorf("rendering method result: unexpected result type %T", result)
+	}
 }
 
 func (m Method) Fields() iter.Seq[Field] {

--- a/targets/python/method.go
+++ b/targets/python/method.go
@@ -4,9 +4,11 @@
 package python
 
 import (
+	"fmt"
 	"iter"
 
 	"github.com/andreychh/tgen/model/ir"
+	"github.com/andreychh/tgen/model/types"
 	"github.com/andreychh/tgen/pkg/iters"
 )
 
@@ -39,11 +41,18 @@ func (m Method) Doc() (string, error) {
 }
 
 func (m Method) ReturnType() (Type, error) {
-	typ, err := m.inner.ReturnType()
+	result, err := m.inner.Result()
 	if err != nil {
 		return Type{}, err
 	}
-	return NewType(typ), nil
+	switch result := result.(type) {
+	case ir.Command:
+		return NewType(ir.NewType(types.NewNamed("True", types.KindPrimitive))), nil
+	case ir.Value:
+		return NewType(result.Type()), nil
+	default:
+		return Type{}, fmt.Errorf("rendering method result: unexpected result type %T", result)
+	}
 }
 
 func (m Method) Fields() iter.Seq[Field] {


### PR DESCRIPTION
This PR introduces a `Result` sum type — `Command` for methods that only signal success, `Value` for methods that carry typed data — and threads it through every layer from `model/spec` down to both targets, replacing `Method.ReturnType()` with `Method.Result()`.

The success/value split is decoded in `model/spec/gq`: the existing return-type parser is left untouched and a method is classified as a `Command` only when its entire return is the literal `True`, so unions that merely contain `True` stay `Value`. Rendering is deliberately unchanged — for now both targets substitute `True` for a `Command`, so the generated output is byte-identical; the future error-only signature will touch only the `ir.Command` branch in each target.

Part of #209