### PR TITLE
Add prose tree model for documentation text

### DIFF
--- a/model/prose/block.go
+++ b/model/prose/block.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package prose
+
+// Paragraph represents a run of inline content delimited as one block.
+type Paragraph struct {
+	inlines []Inline
+}
+
+// NewParagraph constructs a paragraph from inline content.
+func NewParagraph(inlines ...Inline) Paragraph {
+	return Paragraph{inlines: inlines}
+}
+
+// Inlines returns the inline content of the paragraph.
+func (p Paragraph) Inlines() []Inline {
+	return p.inlines
+}
+
+func (Paragraph) isBlock() {}
+
+// CodeBlock represents a verbatim monowidth block.
+type CodeBlock struct {
+	content string
+}
+
+// NewCodeBlock constructs a verbatim block from its content.
+func NewCodeBlock(content string) CodeBlock {
+	return CodeBlock{content: content}
+}
+
+// Content returns the verbatim text of the block.
+func (c CodeBlock) Content() string {
+	return c.content
+}
+
+func (CodeBlock) isBlock() {}
+
+// List represents a sequence of items. Entity-section prose carries only
+// unordered lists, so the tree models no ordering.
+type List struct {
+	items []Item
+}
+
+// NewList constructs a list from its items.
+func NewList(items ...Item) List {
+	return List{items: items}
+}
+
+// Items returns the items of the list.
+func (l List) Items() []Item {
+	return l.items
+}
+
+func (List) isBlock() {}
+
+// Item represents a single list entry of inline content.
+type Item struct {
+	inlines []Inline
+}
+
+// NewItem constructs a list item from inline content.
+func NewItem(inlines ...Inline) Item {
+	return Item{inlines: inlines}
+}
+
+// Inlines returns the inline content of the item.
+func (i Item) Inlines() []Inline {
+	return i.inlines
+}

--- a/model/prose/inline.go
+++ b/model/prose/inline.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package prose
+
+// Text represents a run of plain text.
+type Text struct {
+	content string
+}
+
+// NewText constructs a plain-text run from its content.
+func NewText(content string) Text {
+	return Text{content: content}
+}
+
+// Content returns the text of the run.
+func (t Text) Content() string {
+	return t.content
+}
+
+func (Text) isInline() {}
+
+// Bold represents inline content rendered with strong emphasis.
+type Bold struct {
+	inlines []Inline
+}
+
+// NewBold constructs bold content from inline children.
+func NewBold(inlines ...Inline) Bold {
+	return Bold{inlines: inlines}
+}
+
+// Inlines returns the inline children of the bold run.
+func (b Bold) Inlines() []Inline {
+	return b.inlines
+}
+
+func (Bold) isInline() {}
+
+// Italic represents inline content rendered with emphasis.
+type Italic struct {
+	inlines []Inline
+}
+
+// NewItalic constructs emphasized content from inline children.
+func NewItalic(inlines ...Inline) Italic {
+	return Italic{inlines: inlines}
+}
+
+// Inlines returns the inline children of the emphasized run.
+func (i Italic) Inlines() []Inline {
+	return i.inlines
+}
+
+func (Italic) isInline() {}
+
+// Code represents a verbatim monowidth span.
+type Code struct {
+	content string
+}
+
+// NewCode constructs a verbatim span from its content.
+func NewCode(content string) Code {
+	return Code{content: content}
+}
+
+// Content returns the verbatim text of the span.
+func (c Code) Content() string {
+	return c.content
+}
+
+func (Code) isInline() {}
+
+// Link represents inline content addressing a target URL or anchor.
+type Link struct {
+	target  string
+	inlines []Inline
+}
+
+// NewLink constructs a link to target from inline children.
+func NewLink(target string, inlines ...Inline) Link {
+	return Link{target: target, inlines: inlines}
+}
+
+// Target returns the URL or anchor the link addresses.
+func (l Link) Target() string {
+	return l.target
+}
+
+// Inlines returns the inline children of the link.
+func (l Link) Inlines() []Inline {
+	return l.inlines
+}
+
+func (Link) isInline() {}
+
+// LineBreak represents a forced line break within a block.
+type LineBreak struct{}
+
+// NewLineBreak constructs a line break.
+func NewLineBreak() LineBreak {
+	return LineBreak{}
+}
+
+func (LineBreak) isInline() {}

--- a/model/prose/prose.go
+++ b/model/prose/prose.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package prose models Telegram documentation text as a target-neutral tree of
+// block and inline nodes, decoupled from both the source HTML and any output
+// target. The decoder maps HTML into this tree; each target renders the tree
+// into its own doc-comment syntax. The same tree carries any free-form cell —
+// a field description as much as a field type — so the model names the text,
+// not its role.
+//
+// The tree models only the prose found inside entity sections — objects,
+// methods, and unions. Markup that appears elsewhere on the page (the intro,
+// the changelog, standalone guide sections) is out of scope, so constructs
+// that occur only there have no node: there is no image, because real images
+// live in the intro, and no ordered list, because the one ordered list lives in
+// a guide section.
+package prose
+
+// Block represents a block-level node in a prose tree. The concrete variants
+// are Paragraph, CodeBlock, and List.
+type Block interface {
+	isBlock()
+}
+
+// Inline represents an inline-level node nested within a block. The concrete
+// variants are Text, Bold, Italic, Code, Link, and LineBreak.
+type Inline interface {
+	isInline()
+}
+
+// Tree represents a prose tree as a sequence of blocks.
+type Tree struct {
+	blocks []Block
+}
+
+// NewTree constructs a prose tree from a sequence of blocks.
+func NewTree(blocks ...Block) Tree {
+	return Tree{blocks: blocks}
+}
+
+// Blocks returns the blocks of the prose tree.
+func (t Tree) Blocks() []Block {
+	return t.blocks
+}


### PR DESCRIPTION
This PR introduces the `model/prose` package: a target-neutral tree of block and inline nodes (`Tree`, `Paragraph`, `CodeBlock`, `List`, `Text`, `Bold`, `Italic`, `Code`, `Link`, `LineBreak`) that models documentation prose decoupled from both the source HTML and any output target.

The tree deliberately models only the prose found inside entity sections — objects, methods, and unions — so constructs that occur only elsewhere on the page (images, ordered lists) have no node. The HTML decoder that maps the spec into this tree and the wiring that replaces the flat-string `Description` are left to follow-up work.

Closes #115