### PR TITLE
Merge object fields and method parameters into a unified field table

### DIFF
--- a/.config/golangci.yml
+++ b/.config/golangci.yml
@@ -140,6 +140,7 @@ linters:
       enable-all: true
       disabled-checks:
         - builtinShadow
+        - hugeParam
     godoclint:
       default: all
     nolintlint:

--- a/model/pipeline/operator.go
+++ b/model/pipeline/operator.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package pipeline
+
+import (
+	"fmt"
+)
+
+// Operator produces a table from one or more input tables. Constructing an
+// operator only wires its inputs; Apply runs the operation, returning the
+// resulting table or the failure that prevented it.
+type Operator[K comparable, R Record] interface {
+	Apply() (Table[K, R], error)
+}
+
+// Mapping transforms one record into another. It fails when the record cannot be
+// transformed.
+type Mapping[A, B Record] interface {
+	Apply(record A) (B, error)
+}
+
+// MappedTable is the projection operator: it applies a mapping to every record
+// of a source table, carrying each record's key through unchanged.
+type MappedTable[K comparable, A, B Record] struct {
+	source  Table[K, A]
+	mapping Mapping[A, B]
+}
+
+// NewMappedTable constructs the projection of source through mapping.
+func NewMappedTable[K comparable, A, B Record](
+	source Table[K, A], mapping Mapping[A, B],
+) MappedTable[K, A, B] {
+	return MappedTable[K, A, B]{source: source, mapping: mapping}
+}
+
+// Apply returns the projected table, one record per source record under the same
+// key. It fails when the mapping fails on any record.
+func (t MappedTable[K, A, B]) Apply() (Table[K, B], error) {
+	out := NewMapTableWithCapacity[K, B](t.source.Count())
+	for key, record := range t.source.All() {
+		mapped, err := t.mapping.Apply(record)
+		if err != nil {
+			return out, fmt.Errorf("mapping record %v: %w", key, err)
+		}
+		out.Insert(key, mapped)
+	}
+	return out, nil
+}
+
+// MergedTable is the union operator: it gathers every record from two tables
+// whose key sets are disjoint.
+type MergedTable[K comparable, R Record] struct {
+	left  Table[K, R]
+	right Table[K, R]
+}
+
+// NewMergedTable constructs the union of left and right.
+func NewMergedTable[K comparable, R Record](left, right Table[K, R]) MergedTable[K, R] {
+	return MergedTable[K, R]{left: left, right: right}
+}
+
+// Apply returns the union of the two tables. It fails when a key appears in both,
+// since a key identifies at most one record.
+func (t MergedTable[K, R]) Apply() (Table[K, R], error) {
+	out := NewMapTableWithCapacity[K, R](t.left.Count() + t.right.Count())
+	for _, source := range []Table[K, R]{t.left, t.right} {
+		for key, record := range source.All() {
+			if _, exists := out.Lookup(key); exists {
+				return out, fmt.Errorf("merging tables: key %v present in both", key)
+			}
+			out.Insert(key, record)
+		}
+	}
+	return out, nil
+}

--- a/model/pipeline/unified/field.go
+++ b/model/pipeline/unified/field.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package unified
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// Field is a field of an object or a parameter of a method, reduced to a single
+// shape: its key, the verbatim prose of its type, whether it is optional, and
+// its description with the optional marker removed.
+type Field struct {
+	Key         model.Key
+	Type        prose.Phrase
+	Optionality model.Optionality
+	Description prose.Phrase
+}
+
+// FieldMapping maps a parsed object field into a unified field. An object field
+// carries its optionality as an italic "Optional" prefix in its description,
+// which the mapping lifts out and strips along with the ". " separator that
+// follows it.
+type FieldMapping struct{}
+
+// NewFieldMapping constructs a FieldMapping.
+func NewFieldMapping() FieldMapping {
+	return FieldMapping{}
+}
+
+// Apply implements [pipeline.Mapping]. It fails when the description carries the
+// "Optional" marker without its following ". " separator.
+func (m FieldMapping) Apply(field parsed.Field) (Field, error) {
+	description, optional, err := m.resolveDescription(field.Description)
+	if err != nil {
+		return Field{}, fmt.Errorf("resolving description: %w", err)
+	}
+	return Field{
+		Key:         field.Key,
+		Type:        field.Type,
+		Optionality: model.Optionality(optional),
+		Description: description,
+	}, nil
+}
+
+// resolveDescription splits a field's description into its optionality and
+// normalized prose. A description that does not open with the italic "Optional"
+// marker belongs to a required field and rides through unchanged. One that does
+// is optional: the marker and the ". " separator that follows it are removed. It
+// fails when the marker is present but the ". " separator is not.
+func (m FieldMapping) resolveDescription(
+	description prose.Phrase,
+) (prose.Phrase, bool, error) {
+	inlines := description.Inlines()
+	marker := prose.NewText("Optional", prose.StyleItalic)
+	if len(inlines) == 0 || !inlines[0].Equals(marker) {
+		return description, false, nil
+	}
+	if len(inlines) < 2 {
+		return prose.Phrase{}, false, errors.New(
+			`optional field description lacks a ". " separator`,
+		)
+	}
+	text, ok := inlines[1].(prose.Text)
+	if !ok || text.Style() != prose.StylePlain || !text.HasPrefix(". ") {
+		return prose.Phrase{}, false, errors.New(
+			`optional field description lacks a ". " separator`,
+		)
+	}
+	rest := append([]prose.Inline{text.TrimPrefix(". ")}, inlines[2:]...)
+	return prose.NewPhrase(rest...), true, nil
+}
+
+// ParamMapping maps a parsed method parameter into a unified field. A parameter
+// carries its optionality in a dedicated Required column rather than a
+// description prefix, so its description needs no normalization.
+type ParamMapping struct{}
+
+// NewParamMapping constructs a ParamMapping.
+func NewParamMapping() ParamMapping {
+	return ParamMapping{}
+}
+
+// Apply implements [pipeline.Mapping]. It fails when the Required column is
+// neither "Yes" nor "Optional".
+func (m ParamMapping) Apply(param parsed.Param) (Field, error) {
+	optional, err := m.resolveRequired(param.Required)
+	if err != nil {
+		return Field{}, fmt.Errorf("resolving required column: %w", err)
+	}
+	return Field{
+		Key:         param.Key,
+		Type:        param.Type,
+		Optionality: model.Optionality(optional),
+		Description: param.Description,
+	}, nil
+}
+
+// resolveRequired reads a parameter's Required column, yielding true when it
+// holds "Optional" and false when it holds "Yes". It fails on any other content.
+func (m ParamMapping) resolveRequired(required prose.Phrase) (bool, error) {
+	inlines := required.Inlines()
+	optional := prose.NewText("Optional", prose.StylePlain)
+	yes := prose.NewText("Yes", prose.StylePlain)
+	if len(inlines) != 1 {
+		return false, errors.New("unexpected required column")
+	}
+	if inlines[0].Equals(optional) {
+		return true, nil
+	}
+	if inlines[0].Equals(yes) {
+		return false, nil
+	}
+	return false, errors.New("unexpected required column")
+}

--- a/model/pipeline/unified/specification.go
+++ b/model/pipeline/unified/specification.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package unified merges object fields and method parameters into one table of
+// uniformly shaped fields.
+package unified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+)
+
+// Fields is the table of unified fields, keyed by owner reference and field key.
+type Fields = pipeline.Table[model.FieldKey, Field]
+
+// Specification is the database after object fields and method parameters are
+// merged into a single table of fields. The object, method, union, and variant
+// tables and the release ride through from the parsed stage unchanged.
+type Specification struct {
+	Objects  parsed.Objects
+	Methods  parsed.Methods
+	Fields   Fields
+	Unions   parsed.Unions
+	Variants parsed.Variants
+	Release  parsed.Release
+}
+
+// Pass is the unification stage: it rewrites a parsed specification into a
+// unified one, merging object fields and method parameters into a single table.
+type Pass struct {
+	spec parsed.Specification
+}
+
+// NewPass constructs a Pass over a parsed specification.
+func NewPass(spec parsed.Specification) Pass {
+	return Pass{spec: spec}
+}
+
+// Specification returns the unified specification, merging object fields and
+// method parameters into one table. It fails when any field or parameter cannot
+// be unified.
+func (p Pass) Specification() (Specification, error) {
+	fields, err := pipeline.NewMappedTable(p.spec.Fields, NewFieldMapping()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("unifying fields: %w", err)
+	}
+	params, err := pipeline.NewMappedTable(p.spec.Params, NewParamMapping()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("unifying parameters: %w", err)
+	}
+	merged, err := pipeline.NewMergedTable(fields, params).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("merging fields and parameters: %w", err)
+	}
+	return Specification{
+		Objects:  p.spec.Objects,
+		Methods:  p.spec.Methods,
+		Fields:   merged,
+		Unions:   p.spec.Unions,
+		Variants: p.spec.Variants,
+		Release:  p.spec.Release,
+	}, nil
+}

--- a/model/prose/block.go
+++ b/model/prose/block.go
@@ -3,6 +3,8 @@
 
 package prose
 
+import "slices"
+
 // Paragraph represents a run of inline content delimited as one block.
 type Paragraph struct {
 	inlines []Inline
@@ -16,6 +18,12 @@ func NewParagraph(inlines ...Inline) Paragraph {
 // Inlines returns the inline content of the paragraph.
 func (p Paragraph) Inlines() []Inline {
 	return p.inlines
+}
+
+// Equals reports whether other is a Paragraph with equal inline content.
+func (p Paragraph) Equals(other Block) bool {
+	o, ok := other.(Paragraph)
+	return ok && slices.EqualFunc(p.inlines, o.inlines, Inline.Equals)
 }
 
 func (Paragraph) isBlock() {}
@@ -36,6 +44,12 @@ func (l List) Items() []Item {
 	return l.items
 }
 
+// Equals reports whether other is a List with equal items in the same order.
+func (l List) Equals(other Block) bool {
+	o, ok := other.(List)
+	return ok && slices.EqualFunc(l.items, o.items, Item.Equals)
+}
+
 func (List) isBlock() {}
 
 // Item represents a single list entry of inline content.
@@ -51,4 +65,9 @@ func NewItem(inlines ...Inline) Item {
 // Inlines returns the inline content of the item.
 func (i Item) Inlines() []Inline {
 	return i.inlines
+}
+
+// Equals reports whether other holds the same inline content in the same order.
+func (i Item) Equals(other Item) bool {
+	return slices.EqualFunc(i.inlines, other.inlines, Inline.Equals)
 }

--- a/model/prose/inline.go
+++ b/model/prose/inline.go
@@ -3,6 +3,8 @@
 
 package prose
 
+import "strings"
+
 // Style is the emphasis applied to a text run.
 type Style int
 
@@ -38,6 +40,24 @@ func (t Text) Style() Style {
 	return t.style
 }
 
+// HasPrefix reports whether the run's content begins with prefix.
+func (t Text) HasPrefix(prefix string) bool {
+	return strings.HasPrefix(t.content, prefix)
+}
+
+// TrimPrefix returns the run with prefix removed from the front of its content,
+// keeping its style. The run is returned unchanged when its content lacks the
+// prefix.
+func (t Text) TrimPrefix(prefix string) Text {
+	return Text{content: strings.TrimPrefix(t.content, prefix), style: t.style}
+}
+
+// Equals reports whether other is a Text with the same content and style.
+func (t Text) Equals(other Inline) bool {
+	o, ok := other.(Text)
+	return ok && t.content == o.content && t.style == o.style
+}
+
 func (Text) isInline() {}
 
 // Link represents a styled text run that addresses a target URL or anchor.
@@ -67,6 +87,31 @@ func (l Link) Href() string {
 	return l.href
 }
 
+// Telegram Bot API 10.1 uses three href forms across the documentation prose:
+//   - "#section"  — an anchor into the same page; the only form inside type cells
+//   - "https://…" — an absolute URL to an external resource (descriptions only)
+//   - "/path"     — a path relative to the documentation site root (descriptions only)
+//
+// Only the anchor form denotes a documented type, so that is the one distinction
+// Anchor draws; the others may earn their own modeling once descriptions are
+// rendered into absolute links.
+
+// Anchor returns the fragment the link targets and reports whether the link is
+// an anchor — an in-page reference of the form "#section". The fragment is
+// returned without its leading "#", and is empty when the link is not an anchor.
+func (l Link) Anchor() (string, bool) {
+	if !strings.HasPrefix(l.href, "#") {
+		return "", false
+	}
+	return strings.TrimPrefix(l.href, "#"), true
+}
+
+// Equals reports whether other is a Link with the same content, style, and href.
+func (l Link) Equals(other Inline) bool {
+	o, ok := other.(Link)
+	return ok && l.content == o.content && l.style == o.style && l.href == o.href
+}
+
 func (Link) isInline() {}
 
 // LineBreak represents a forced line break within a block.
@@ -75,6 +120,12 @@ type LineBreak struct{}
 // NewLineBreak constructs a line break.
 func NewLineBreak() LineBreak {
 	return LineBreak{}
+}
+
+// Equals reports whether other is also a LineBreak.
+func (LineBreak) Equals(other Inline) bool {
+	_, ok := other.(LineBreak)
+	return ok
 }
 
 func (LineBreak) isInline() {}

--- a/model/prose/prose.go
+++ b/model/prose/prose.go
@@ -24,16 +24,22 @@
 // [Text] or [Link] carries one [Style] rather than a subtree of inline nodes.
 package prose
 
+import "slices"
+
 // Block represents a block-level node in a prose tree. The concrete variants
 // are [Paragraph] and [List].
 type Block interface {
 	isBlock()
+	// Equals reports whether other is the same block variant with equal content.
+	Equals(other Block) bool
 }
 
 // Inline represents an inline-level node within a block or phrase. The concrete
 // variants are [Text], [Link], and [LineBreak].
 type Inline interface {
 	isInline()
+	// Equals reports whether other is the same inline variant with equal content.
+	Equals(other Inline) bool
 }
 
 // Passage represents prose as a sequence of blocks.
@@ -49,6 +55,11 @@ func NewPassage(blocks ...Block) Passage {
 // Blocks returns the blocks of the passage.
 func (p Passage) Blocks() []Block {
 	return p.blocks
+}
+
+// Equals reports whether other holds the same blocks in the same order.
+func (p Passage) Equals(other Passage) bool {
+	return slices.EqualFunc(p.blocks, other.blocks, Block.Equals)
 }
 
 // Phrase represents prose as a sequence of inline runs, with no block
@@ -67,4 +78,9 @@ func NewPhrase(inlines ...Inline) Phrase {
 // Inlines returns the inline content of the phrase.
 func (p Phrase) Inlines() []Inline {
 	return p.inlines
+}
+
+// Equals reports whether other holds the same inline runs in the same order.
+func (p Phrase) Equals(other Phrase) bool {
+	return slices.EqualFunc(p.inlines, other.inlines, Inline.Equals)
 }


### PR DESCRIPTION
This PR adds a `unified` pass that maps parsed object fields and method parameters into one uniformly shaped `Field` table, lifting optionality out of each source's own representation — an italic `Optional` prefix for fields, a `Required` column for parameters — and stripping the marker from field descriptions.

The merge is expressed through two reusable relational operators, `MappedTable` and `MergedTable`, so the projection and disjoint-union steps compose and fail loudly when a key appears in both sources. Supporting this, `prose` gains structural equality across its nodes plus the text helpers used to detect and trim the `Optional` prefix.

Closes #216