### PR TITLE
Decode type-cell prose into a `types` expression tree

### DIFF
--- a/model/pipeline/typed/types/cursor.go
+++ b/model/pipeline/typed/types/cursor.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+// Cursor is a one-pass reader over a slice of items, consuming them one at a
+// time from the front.
+type Cursor[T any] struct {
+	items []T
+	pos   int
+}
+
+// NewCursor constructs a Cursor positioned before the first item.
+func NewCursor[T any](items []T) *Cursor[T] {
+	return &Cursor[T]{
+		items: items,
+		pos:   0,
+	}
+}
+
+// Peek returns the current item without consuming it. The boolean reports
+// whether an item was available; on an exhausted cursor it is false and the
+// item is the zero value.
+func (c *Cursor[T]) Peek() (T, bool) {
+	if c.Done() {
+		var zero T
+		return zero, false
+	}
+	return c.items[c.pos], true
+}
+
+// Take consumes the current item and returns it. The boolean reports whether an
+// item was available; on an exhausted cursor it is false and the item is the
+// zero value.
+func (c *Cursor[T]) Take() (T, bool) {
+	if c.Done() {
+		var zero T
+		return zero, false
+	}
+	item := c.items[c.pos]
+	c.pos++
+	return item, true
+}
+
+// Skip consumes the current item without returning it, advancing the cursor.
+func (c *Cursor[T]) Skip() {
+	c.pos++
+}
+
+// Done reports whether the cursor has no items left to consume.
+func (c *Cursor[T]) Done() bool {
+	return c.pos >= len(c.items)
+}

--- a/model/pipeline/typed/types/expression.go
+++ b/model/pipeline/typed/types/expression.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package types decodes the prose of a field's type column into a type
+// expression.
+package types
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// Expression is the prose of a field's type column, ready to be decoded into
+// a type expression.
+type Expression struct {
+	phrase prose.Phrase
+}
+
+// NewExpression constructs an Expression over the prose of a type column.
+func NewExpression(phrase prose.Phrase) Expression {
+	return Expression{phrase: phrase}
+}
+
+// Value returns the type expression decoded from the prose. It fails when the
+// prose lexes to an unknown token or does not form a valid type expression.
+//
+//nolint:ireturn // types.Expression is the intentional decoded contract.
+func (e Expression) Value() (types.Expression, error) {
+	tokens, err := NewLexer(e.phrase).Tokens()
+	if err != nil {
+		return nil, fmt.Errorf("lexing type expression: %w", err)
+	}
+	expr, err := NewParser(NewCursor(tokens)).Expression()
+	if err != nil {
+		return nil, fmt.Errorf("parsing type expression: %w", err)
+	}
+	return expr, nil
+}

--- a/model/pipeline/typed/types/lexer.go
+++ b/model/pipeline/typed/types/lexer.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// Lexer tokenizes the prose of a type cell, recognizing built-in type words
+// through a primitive vocabulary.
+type Lexer struct {
+	phrase     prose.Phrase
+	primitives types.Primitives
+}
+
+// NewLexer constructs a Lexer over the prose of a type cell, using the default
+// primitive vocabulary.
+func NewLexer(phrase prose.Phrase) Lexer {
+	return Lexer{phrase: phrase, primitives: types.NewPrimitives()}
+}
+
+// Tokens lexes the phrase into its tokens. It fails on a non-anchor link, an
+// unknown word, or an inline that is neither text nor a link.
+func (l Lexer) Tokens() ([]Token, error) {
+	var out []Token
+	for _, node := range l.phrase.Inlines() {
+		tokens, err := l.inline(node)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, tokens...)
+	}
+	return out, nil
+}
+
+// inline lexes a single inline node into its tokens. It fails on a non-anchor
+// link or an inline that is neither text nor a link.
+func (l Lexer) inline(node prose.Inline) ([]Token, error) {
+	switch node := node.(type) {
+	case prose.Link:
+		target, ok := node.Anchor()
+		if !ok {
+			return nil, fmt.Errorf("type link %q is not an anchor", node.Href())
+		}
+		return []Token{NewRef(model.Reference(target))}, nil
+	case prose.Text:
+		return l.words(node.Content())
+	default:
+		return nil, fmt.Errorf("unexpected inline %T in type expression", node)
+	}
+}
+
+// words lexes the content of a text run into its structural and primitive
+// tokens. It fails when a word is neither a keyword nor a known primitive.
+func (l Lexer) words(content string) ([]Token, error) {
+	var out []Token
+	cursor := NewCursor(split(content))
+	for {
+		word, ok := cursor.Take()
+		if !ok {
+			break
+		}
+		switch word {
+		case "Array":
+			next, found := cursor.Take()
+			if !found || next != "of" {
+				return nil, errors.New(`expected "of" after "Array"`)
+			}
+			out = append(out, NewArrayOf())
+		case "or", "and", ",":
+			out = append(out, NewSeparator())
+		default:
+			kind, known := l.primitives.Kind(word)
+			if !known {
+				return nil, fmt.Errorf("unknown type word %q", word)
+			}
+			out = append(out, NewPrimitive(kind))
+		}
+	}
+	return out, nil
+}
+
+// split breaks a text run into words, treating each comma as its own word.
+func split(content string) []string {
+	return strings.Fields(strings.ReplaceAll(content, ",", " , "))
+}

--- a/model/pipeline/typed/types/parser.go
+++ b/model/pipeline/typed/types/parser.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"errors"
+
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// Parser decodes a stream of type tokens into a type expression by recursive
+// descent. The grammar is:
+//
+//	expression := term (separator term)*
+//	term       := "Array of" expression | ref | primitive
+//
+// Precedence is implicit in the rule layering: "Array of" recurses into a whole
+// expression, so a union inside an array (the comma-and form) binds as the
+// array's element, while a top-level union (the "or" form) joins terms.
+type Parser struct {
+	tokens *Cursor[Token]
+}
+
+// NewParser constructs a Parser over a cursor of type-expression tokens.
+func NewParser(tokens *Cursor[Token]) Parser {
+	return Parser{tokens: tokens}
+}
+
+// Expression returns the type expression decoded from the whole token stream. It
+// fails when the tokens are malformed or do not all form a single expression.
+//
+//nolint:ireturn // types.Expression is the intentional decoded contract.
+func (p Parser) Expression() (types.Expression, error) {
+	expr, err := p.expression()
+	if err != nil {
+		return nil, err
+	}
+	if !p.tokens.Done() {
+		return nil, errors.New("trailing tokens after type expression")
+	}
+	return expr, nil
+}
+
+// expression parses a term, then folds any separator-joined terms that follow
+// into a Union. It fails when a term is malformed.
+//
+//nolint:ireturn // types.Expression is the recursive node contract.
+func (p Parser) expression() (types.Expression, error) {
+	first, err := p.term()
+	if err != nil {
+		return nil, err
+	}
+	variants := []types.Expression{first}
+	for p.atSeparator() {
+		p.tokens.Skip()
+		next, err := p.term()
+		if err != nil {
+			return nil, err
+		}
+		variants = append(variants, next)
+	}
+	if len(variants) == 1 {
+		return variants[0], nil
+	}
+	return types.NewUnion(variants...), nil
+}
+
+// term parses an "Array of" wrapper around a nested expression, or a single
+// reference or primitive. It fails on the end of input or a token that cannot
+// begin a type.
+//
+//nolint:ireturn // types.Expression is the recursive node contract.
+func (p Parser) term() (types.Expression, error) {
+	node, ok := p.tokens.Take()
+	if !ok {
+		return nil, errors.New("expected a type, found end of input")
+	}
+	switch node := node.(type) {
+	case ArrayOf:
+		element, err := p.expression()
+		if err != nil {
+			return nil, err
+		}
+		return types.NewArray(element), nil
+	case Ref:
+		return types.NewNamed(node.Reference()), nil
+	case Primitive:
+		return types.NewPrimitive(node.Kind()), nil
+	default:
+		return nil, errors.New("expected a type")
+	}
+}
+
+// atSeparator reports whether the next token is a separator, without consuming
+// it.
+func (p Parser) atSeparator() bool {
+	token, ok := p.tokens.Peek()
+	_, sep := token.(Separator)
+	return ok && sep
+}

--- a/model/pipeline/typed/types/token.go
+++ b/model/pipeline/typed/types/token.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// Token is one lexical unit of a type expression. Its variants split into value
+// tokens that denote a type ([Ref], [Primitive]) and structural tokens that mark
+// composition ([ArrayOf], [Separator]).
+type Token interface {
+	isToken()
+}
+
+// Ref is a reference to a documented type, decoded from a link's anchor.
+type Ref struct {
+	reference model.Reference
+}
+
+// NewRef constructs a Ref denoting the documented type at reference.
+func NewRef(reference model.Reference) Ref {
+	return Ref{reference: reference}
+}
+
+// Reference returns the reference to the documented type the token denotes.
+func (r Ref) Reference() model.Reference {
+	return r.reference
+}
+
+func (Ref) isToken() {}
+
+// Primitive is a built-in type word, one of the closed PrimitiveKind set.
+type Primitive struct {
+	kind types.PrimitiveKind
+}
+
+// NewPrimitive constructs a Primitive denoting the built-in type kind.
+func NewPrimitive(kind types.PrimitiveKind) Primitive {
+	return Primitive{kind: kind}
+}
+
+// Kind returns the built-in type the token denotes.
+func (p Primitive) Kind() types.PrimitiveKind {
+	return p.kind
+}
+
+func (Primitive) isToken() {}
+
+// ArrayOf is the "Array of" prefix that wraps the following type.
+type ArrayOf struct{}
+
+// NewArrayOf constructs an ArrayOf prefix token.
+func NewArrayOf() ArrayOf {
+	return ArrayOf{}
+}
+
+func (ArrayOf) isToken() {}
+
+// Separator divides the variants of a union. The spec writes it as "or" at the
+// top level and as commas with a final "and" inside an array element; all three
+// mean the same thing.
+type Separator struct{}
+
+// NewSeparator constructs a Separator token.
+func NewSeparator() Separator {
+	return Separator{}
+}
+
+func (Separator) isToken() {}

--- a/model/types/v2/array.go
+++ b/model/types/v2/array.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+// Array represents a homogeneous sequence of an element type.
+type Array struct {
+	element Expression
+}
+
+// NewArray constructs an array type from its element type.
+func NewArray(element Expression) Array {
+	return Array{element: element}
+}
+
+// Element returns the element type of the array.
+func (a Array) Element() Expression {
+	return a.element
+}
+
+// Equals reports whether other is an Array with an equal element type.
+func (a Array) Equals(other Expression) bool {
+	if other, ok := other.(Array); ok {
+		return a.element.Equals(other.element)
+	}
+	return false
+}
+
+func (Array) isNode() {}

--- a/model/types/v2/named.go
+++ b/model/types/v2/named.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import "github.com/andreychh/tgen/model"
+
+// Named represents a reference to a documented type — an object or a union —
+// addressed by the anchor of its definition.
+type Named struct {
+	ref model.Reference
+}
+
+// NewNamed constructs a named type from the reference of its definition.
+func NewNamed(ref model.Reference) Named {
+	return Named{ref: ref}
+}
+
+// Ref returns the reference of the named type's definition.
+func (n Named) Ref() model.Reference {
+	return n.ref
+}
+
+// Equals reports whether other is a Named with the same reference.
+func (n Named) Equals(other Expression) bool {
+	if other, ok := other.(Named); ok {
+		return n.ref == other.ref
+	}
+	return false
+}
+
+func (Named) isNode() {}

--- a/model/types/v2/primitive.go
+++ b/model/types/v2/primitive.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+// Primitive represents a built-in type the spec uses without an anchor.
+type Primitive struct {
+	kind PrimitiveKind
+}
+
+// NewPrimitive constructs a primitive type of the given kind.
+func NewPrimitive(kind PrimitiveKind) Primitive {
+	return Primitive{kind: kind}
+}
+
+// Kind returns the kind of the primitive.
+func (p Primitive) Kind() PrimitiveKind {
+	return p.kind
+}
+
+// Equals reports whether other is a Primitive of the same kind.
+func (p Primitive) Equals(other Expression) bool {
+	if other, ok := other.(Primitive); ok {
+		return p.kind == other.kind
+	}
+	return false
+}
+
+func (Primitive) isNode() {}

--- a/model/types/v2/types.go
+++ b/model/types/v2/types.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package types models a field type as an algebraic tree of named, primitive,
+// array, and union nodes. The spec's type prose maps into this tree; targets
+// traverse it to render their own type syntax.
+package types
+
+// PrimitiveKind enumerates the built-in types the spec uses without an anchor
+// of their own.
+type PrimitiveKind string
+
+const (
+	Integer PrimitiveKind = "Integer"
+	String  PrimitiveKind = "String"
+	Boolean PrimitiveKind = "Boolean"
+	Float   PrimitiveKind = "Float"
+	True    PrimitiveKind = "True"
+)
+
+// Primitives is the vocabulary of built-in type words, mapping each spelling —
+// canonical or alias — to its kind.
+type Primitives struct {
+	spellings map[string]PrimitiveKind
+}
+
+// NewPrimitives constructs the vocabulary of built-in type words, recognizing
+// each PrimitiveKind by its canonical spelling and known aliases.
+func NewPrimitives() Primitives {
+	return Primitives{
+		spellings: map[string]PrimitiveKind{
+			"Integer": Integer,
+			"Int":     Integer,
+			"String":  String,
+			"Boolean": Boolean,
+			"Float":   Float,
+			"True":    True,
+		},
+	}
+}
+
+// Kind returns the kind named by word, reporting whether word is a built-in type
+// word in the vocabulary.
+func (p Primitives) Kind(word string) (PrimitiveKind, bool) {
+	kind, ok := p.spellings[word]
+	return kind, ok
+}
+
+// Expression represents a field type as a tree. The concrete variants are
+// Named, Primitive, Array, and Union.
+//
+//sumtype:decl
+type Expression interface {
+	Equals(other Expression) bool
+	isNode()
+}

--- a/model/types/v2/union.go
+++ b/model/types/v2/union.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"slices"
+)
+
+// Union represents a choice between several variant types.
+type Union struct {
+	variants []Expression
+}
+
+// NewUnion constructs a union type from its variant types.
+func NewUnion(variants ...Expression) Union {
+	return Union{variants: variants}
+}
+
+// Variants returns the variant types of the union.
+func (u Union) Variants() []Expression {
+	return u.variants
+}
+
+// Equals reports whether other is a Union with equal variant types in order.
+func (u Union) Equals(other Expression) bool {
+	if other, ok := other.(Union); ok {
+		return slices.EqualFunc(u.variants, other.variants, Expression.Equals)
+	}
+	return false
+}
+
+func (Union) isNode() {}


### PR DESCRIPTION
This PR adds a `types` algebraic tree — `Named`, `Primitive`, `Array`, and `Union` — and a `typed/types` decoder that lexes a field's type-cell prose into tokens and parses them into that tree by recursive descent.

Precedence is left implicit in the grammar's rule layering rather than encoded explicitly: `Array of` recurses into a whole expression, so a comma-and union binds as an array's element while a top-level `or` union joins terms. Built-in type words are recognized through a `Primitives` vocabulary that maps each spelling, canonical or alias, to its kind.

Closes #217