### PR TITLE
Add `resolved` pipeline layer with method return type decoding

### DIFF
--- a/model/pipeline/operator.go
+++ b/model/pipeline/operator.go
@@ -14,8 +14,8 @@ type Operator[K comparable, R Record] interface {
 	Apply() (Table[K, R], error)
 }
 
-// Mapping transforms one record into another. It fails when the record cannot be
-// transformed.
+// Mapping transforms one record into another. It fails when the record cannot
+// be transformed.
 type Mapping[A, B Record] interface {
 	Apply(record A) (B, error)
 }
@@ -34,8 +34,8 @@ func NewMappedTable[K comparable, A, B Record](
 	return MappedTable[K, A, B]{source: source, mapping: mapping}
 }
 
-// Apply returns the projected table, one record per source record under the same
-// key. It fails when the mapping fails on any record.
+// Apply returns the projected table, one record per source record under the
+// same key. It fails when the mapping fails on any record.
 func (t MappedTable[K, A, B]) Apply() (Table[K, B], error) {
 	out := NewMapTableWithCapacity[K, B](t.source.Count())
 	for key, record := range t.source.All() {
@@ -60,8 +60,8 @@ func NewMergedTable[K comparable, R Record](left, right Table[K, R]) MergedTable
 	return MergedTable[K, R]{left: left, right: right}
 }
 
-// Apply returns the union of the two tables. It fails when a key appears in both,
-// since a key identifies at most one record.
+// Apply returns the union of the two tables. It fails when a key appears in
+// both, since a key identifies at most one record.
 func (t MergedTable[K, R]) Apply() (Table[K, R], error) {
 	out := NewMapTableWithCapacity[K, R](t.left.Count() + t.right.Count())
 	for _, source := range []Table[K, R]{t.left, t.right} {

--- a/model/pipeline/parsed/prose/prose.go
+++ b/model/pipeline/parsed/prose/prose.go
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 // Package prose decodes the documentation source of an entity section into the
-// flat prose model: a passage of blocks for a section body, a phrase of runs for
-// a table cell. It maps the closed set of HTML nodes that occur in such
+// flat prose model: a passage of blocks for a section body, a phrase of runs
+// for a table cell. It maps the closed set of HTML nodes that occur in such
 // sections, and rejects any markup the model cannot represent.
 package prose
 

--- a/model/pipeline/resolved/method.go
+++ b/model/pipeline/resolved/method.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package resolved
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/resolved/types"
+	"github.com/andreychh/tgen/model/result"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+// Method is the decoded record of a documentation method after its return type
+// is resolved: its reference, name, and what it returns.
+type Method struct {
+	Ref    model.Reference
+	Name   model.Name
+	Result result.Result
+}
+
+// MethodMapping maps a parsed method into a resolved method by decoding its
+// return type from description prose into a result.
+type MethodMapping struct{}
+
+// NewMethodMapping constructs a MethodMapping.
+func NewMethodMapping() MethodMapping {
+	return MethodMapping{}
+}
+
+// Apply implements [pipeline.Mapping]. It fails when the method's description
+// prose does not contain a recognizable return clause.
+func (m MethodMapping) Apply(method parsed.Method) (Method, error) {
+	expr, err := types.NewReturnType(method.Description).Value()
+	if err != nil {
+		return Method{}, fmt.Errorf("decoding return type: %w", err)
+	}
+	return Method{
+		Ref:    method.Ref,
+		Name:   method.Name,
+		Result: m.classify(expr),
+	}, nil
+}
+
+// classify returns [result.Confirmation] when expr is the True primitive, and
+// [result.Value] otherwise.
+func (m MethodMapping) classify(expr typetree.Expression) result.Result {
+	if expr.Equals(typetree.NewPrimitive(typetree.True)) {
+		return result.NewConfirmation()
+	}
+	return result.NewValue(expr)
+}

--- a/model/pipeline/resolved/specification.go
+++ b/model/pipeline/resolved/specification.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package resolved decodes the return type of each method from its description
+// prose into a [result.Result].
+package resolved
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+)
+
+// Methods is the table of resolved methods, keyed by reference.
+type Methods = pipeline.Table[model.Reference, Method]
+
+// Specification is the database after every method's return type is decoded
+// from its description prose into a [result.Result]. The object, field, union,
+// and variant tables and the release ride through from the typed stage
+// unchanged.
+type Specification struct {
+	Objects  parsed.Objects
+	Methods  Methods
+	Fields   typed.Fields
+	Unions   parsed.Unions
+	Variants parsed.Variants
+	Release  parsed.Release
+}
+
+// Pass is the resolution stage: it rewrites a typed specification into a
+// resolved one, decoding every method's return type from its description prose.
+type Pass struct {
+	spec typed.Specification
+}
+
+// NewPass constructs a Pass over a typed specification.
+func NewPass(spec typed.Specification) Pass {
+	return Pass{spec: spec}
+}
+
+// Specification returns the resolved specification, decoding every method's
+// return type from its description prose into a [result.Result]. It fails when
+// any method's return type prose cannot be decoded.
+func (p Pass) Specification() (Specification, error) {
+	methods, err := pipeline.NewMappedTable(p.spec.Methods, NewMethodMapping()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("resolving methods: %w", err)
+	}
+	return Specification{
+		Objects:  p.spec.Objects,
+		Methods:  methods,
+		Fields:   p.spec.Fields,
+		Unions:   p.spec.Unions,
+		Variants: p.spec.Variants,
+		Release:  p.spec.Release,
+	}, nil
+}

--- a/model/pipeline/resolved/types/matchers.go
+++ b/model/pipeline/resolved/types/matchers.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package types decodes the prose of a method's return clause into a type
+// expression.
+//
+// [ReturnType] is the entry point: wrap a method's description prose and call
+// its Value method to obtain the return type.
+//
+// Decoding is driven by [Rule] implementations — [ReturnsRule], [ReturnedRule],
+// [ArrayRule], and [UnionRule] — each recognizing one structural form of the
+// clause. [ProductionRule] tries them in priority order; [Search] applies the
+// combined rule at every position in the paragraph until one matches.
+package types
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// Marker represents a prose signal word — "Returns", "is returned", "Array of"
+// — recognized by a regular expression against plain text runs.
+type Marker struct {
+	pattern *regexp.Regexp
+}
+
+// NewMarker constructs a Marker from pattern.
+func NewMarker(pattern *regexp.Regexp) Marker {
+	return Marker{pattern: pattern}
+}
+
+// Matches reports whether the inline is a plain text run whose content
+// satisfies the marker's regular expression.
+func (m Marker) Matches(inline prose.Inline) bool {
+	text, ok := inline.(prose.Text)
+	return ok && text.Style() == prose.StylePlain && m.pattern.MatchString(text.Content())
+}
+
+// Named represents an in-page anchor link, the form a return clause uses to
+// identify a documented type.
+type Named struct{}
+
+// NewNamed constructs a Named.
+func NewNamed() Named {
+	return Named{}
+}
+
+// Matches reports whether the inline is a link to an in-page anchor and returns
+// the reference it addresses. The reference is empty when the report is false.
+func (Named) Matches(inline prose.Inline) (model.Reference, bool) {
+	link, ok := inline.(prose.Link)
+	if !ok {
+		return "", false
+	}
+	target, ok := link.Anchor()
+	if !ok {
+		return "", false
+	}
+	return model.Reference(target), true
+}
+
+// Primitive represents the italic keyword form that a return clause uses for
+// built-in types such as True, String, and Float.
+type Primitive struct {
+	primitives types.Primitives
+}
+
+// NewPrimitive constructs a Primitive over the default primitive vocabulary.
+func NewPrimitive() Primitive {
+	return Primitive{primitives: types.NewPrimitives()}
+}
+
+// Matches reports whether the inline is an italic text run naming a built-in
+// type and returns the kind it names. The kind is empty when the report is
+// false.
+func (p Primitive) Matches(inline prose.Inline) (types.PrimitiveKind, bool) {
+	text, ok := inline.(prose.Text)
+	if !ok || text.Style() != prose.StyleItalic {
+		return "", false
+	}
+	return p.primitives.Kind(strings.TrimSpace(text.Content()))
+}

--- a/model/pipeline/resolved/types/production.go
+++ b/model/pipeline/resolved/types/production.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// ProductionRule is a [Rule] composed of other rules tried in priority order.
+type ProductionRule struct {
+	rules []Rule
+}
+
+// NewProductionRule constructs a ProductionRule from its rules, in priority
+// order.
+func NewProductionRule(rules ...Rule) ProductionRule {
+	return ProductionRule{rules: rules}
+}
+
+// Match implements [Rule].
+func (p ProductionRule) Match(inlines []prose.Inline) (types.Expression, bool) {
+	for _, rule := range p.rules {
+		if expr, ok := rule.Match(inlines); ok {
+			return expr, true
+		}
+	}
+	return nil, false
+}

--- a/model/pipeline/resolved/types/return_type.go
+++ b/model/pipeline/resolved/types/return_type.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"errors"
+
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// ReturnType is a method's description ready to be decoded into the type it
+// returns.
+type ReturnType struct {
+	description prose.Passage
+}
+
+// NewReturnType constructs a ReturnType over a method's description.
+func NewReturnType(description prose.Passage) ReturnType {
+	return ReturnType{description: description}
+}
+
+// Value returns the type expression decoded from the return clause in the first
+// paragraph of the description. It fails when the description has no first
+// paragraph or no rule recognizes the return clause.
+func (r ReturnType) Value() (types.Expression, error) {
+	blocks := r.description.Blocks()
+	if len(blocks) == 0 {
+		return nil, errors.New("method description has no blocks")
+	}
+	paragraph, ok := blocks[0].(prose.Paragraph)
+	if !ok {
+		return nil, errors.New("method description does not open with a paragraph")
+	}
+	expr, found := NewSearch(rules()).Find(paragraph.Inlines())
+	if !found {
+		return nil, errors.New("no rule matched the return clause")
+	}
+	return expr, nil
+}
+
+// rules assembles the return-clause production in priority order: the specific
+// array and union forms before the plain named and primitive forms, so a clause
+// like "Array of Update" is not first claimed by a plain named or primitive
+// rule.
+func rules() ProductionRule {
+	return NewProductionRule(
+		NewUnionRule(),
+		NewArrayRule(),
+		NewReturnsRule(),
+		NewReturnedRule(),
+	)
+}

--- a/model/pipeline/resolved/types/rule.go
+++ b/model/pipeline/resolved/types/rule.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"regexp"
+
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+var (
+	returnsSignal   = regexp.MustCompile(`(?i)\breturns\b`)
+	returnedSignal  = regexp.MustCompile(`(?i)is returned`)
+	arrayOfSignal   = regexp.MustCompile(`(?i)array of`)
+	otherwiseSignal = regexp.MustCompile(`(?i)otherwise`)
+)
+
+// Rule is a pattern that recognizes one structural form of a return clause,
+// decoding it into the type expression the clause names.
+type Rule interface {
+	// Match reports whether the rule's form begins at the front of inlines and
+	// returns the type expression it names. It reports false when the form does not
+	// start at inlines[0], leaving the caller to advance or try another rule.
+	Match(inlines []prose.Inline) (types.Expression, bool)
+}
+
+// ReturnsRule is a [Rule] that recognizes "Returns <type>", where the type is
+// either a link to a documented type or an italic primitive word.
+type ReturnsRule struct{}
+
+// NewReturnsRule constructs a ReturnsRule.
+func NewReturnsRule() ReturnsRule {
+	return ReturnsRule{}
+}
+
+// Match implements [Rule].
+func (ReturnsRule) Match(inlines []prose.Inline) (types.Expression, bool) {
+	if len(inlines) < 2 {
+		return nil, false
+	}
+	if !NewMarker(returnsSignal).Matches(inlines[0]) {
+		return nil, false
+	}
+	if ref, ok := NewNamed().Matches(inlines[1]); ok {
+		return types.NewNamed(ref), true
+	}
+	kind, ok := NewPrimitive().Matches(inlines[1])
+	if !ok {
+		return nil, false
+	}
+	return types.NewPrimitive(kind), true
+}
+
+// ReturnedRule is a [Rule] that recognizes "<type> is returned", where the type
+// is either a link to a documented type or an italic primitive word.
+type ReturnedRule struct{}
+
+// NewReturnedRule constructs a ReturnedRule.
+func NewReturnedRule() ReturnedRule {
+	return ReturnedRule{}
+}
+
+// Match implements [Rule].
+func (ReturnedRule) Match(inlines []prose.Inline) (types.Expression, bool) {
+	if len(inlines) < 2 {
+		return nil, false
+	}
+	if !NewMarker(returnedSignal).Matches(inlines[1]) {
+		return nil, false
+	}
+	if ref, ok := NewNamed().Matches(inlines[0]); ok {
+		return types.NewNamed(ref), true
+	}
+	kind, ok := NewPrimitive().Matches(inlines[0])
+	if !ok {
+		return nil, false
+	}
+	return types.NewPrimitive(kind), true
+}
+
+// ArrayRule is a [Rule] that recognizes "Array of <named>", a sequence whose
+// element is a documented type.
+type ArrayRule struct{}
+
+// NewArrayRule constructs an ArrayRule.
+func NewArrayRule() ArrayRule {
+	return ArrayRule{}
+}
+
+// Match implements [Rule].
+func (ArrayRule) Match(inlines []prose.Inline) (types.Expression, bool) {
+	if len(inlines) < 2 {
+		return nil, false
+	}
+	if !NewMarker(arrayOfSignal).Matches(inlines[0]) {
+		return nil, false
+	}
+	ref, ok := NewNamed().Matches(inlines[1])
+	if !ok {
+		return nil, false
+	}
+	return types.NewArray(types.NewNamed(ref)), true
+}
+
+// UnionRule is a [Rule] that recognizes "<named> is returned, otherwise
+// <primitive> is returned", a conditional return between a documented type and
+// a primitive.
+type UnionRule struct{}
+
+// NewUnionRule constructs a UnionRule.
+func NewUnionRule() UnionRule {
+	return UnionRule{}
+}
+
+// Match implements [Rule].
+func (UnionRule) Match(inlines []prose.Inline) (types.Expression, bool) {
+	if len(inlines) < 4 {
+		return nil, false
+	}
+	ref, ok := NewNamed().Matches(inlines[0])
+	if !ok {
+		return nil, false
+	}
+	if !NewMarker(otherwiseSignal).Matches(inlines[1]) {
+		return nil, false
+	}
+	kind, found := NewPrimitive().Matches(inlines[2])
+	if !found {
+		return nil, false
+	}
+	if !NewMarker(returnedSignal).Matches(inlines[3]) {
+		return nil, false
+	}
+	return types.NewUnion(types.NewNamed(ref), types.NewPrimitive(kind)), true
+}

--- a/model/pipeline/resolved/types/search.go
+++ b/model/pipeline/resolved/types/search.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/types/v2"
+)
+
+// Search represents a scan of an inline run for the first position where a
+// given [Rule] matches.
+type Search struct {
+	rule Rule
+}
+
+// NewSearch constructs a Search over rule.
+func NewSearch(rule Rule) Search {
+	return Search{rule: rule}
+}
+
+// Find returns the type expression decoded at the first position in inlines
+// where the rule matches, or false when no position matches.
+func (s Search) Find(inlines []prose.Inline) (types.Expression, bool) {
+	for offset := range inlines {
+		if expr, ok := s.rule.Match(inlines[offset:]); ok {
+			return expr, true
+		}
+	}
+	return nil, false
+}

--- a/model/pipeline/typed/types/expression.go
+++ b/model/pipeline/typed/types/expression.go
@@ -12,8 +12,8 @@ import (
 	"github.com/andreychh/tgen/model/types/v2"
 )
 
-// Expression is the prose of a field's type column, ready to be decoded into
-// a type expression.
+// Expression is the prose of a field's type column, ready to be decoded into a
+// type expression.
 type Expression struct {
 	phrase prose.Phrase
 }
@@ -25,8 +25,6 @@ func NewExpression(phrase prose.Phrase) Expression {
 
 // Value returns the type expression decoded from the prose. It fails when the
 // prose lexes to an unknown token or does not form a valid type expression.
-//
-//nolint:ireturn // types.Expression is the intentional decoded contract.
 func (e Expression) Value() (types.Expression, error) {
 	tokens, err := NewLexer(e.phrase).Tokens()
 	if err != nil {

--- a/model/pipeline/typed/types/parser.go
+++ b/model/pipeline/typed/types/parser.go
@@ -27,10 +27,9 @@ func NewParser(tokens *Cursor[Token]) Parser {
 	return Parser{tokens: tokens}
 }
 
-// Expression returns the type expression decoded from the whole token stream. It
-// fails when the tokens are malformed or do not all form a single expression.
-//
-//nolint:ireturn // types.Expression is the intentional decoded contract.
+// Expression returns the type expression decoded from the whole token stream.
+// It fails when the tokens are malformed or do not all form a single
+// expression.
 func (p Parser) Expression() (types.Expression, error) {
 	expr, err := p.expression()
 	if err != nil {
@@ -44,8 +43,6 @@ func (p Parser) Expression() (types.Expression, error) {
 
 // expression parses a term, then folds any separator-joined terms that follow
 // into a Union. It fails when a term is malformed.
-//
-//nolint:ireturn // types.Expression is the recursive node contract.
 func (p Parser) expression() (types.Expression, error) {
 	first, err := p.term()
 	if err != nil {
@@ -69,8 +66,6 @@ func (p Parser) expression() (types.Expression, error) {
 // term parses an "Array of" wrapper around a nested expression, or a single
 // reference or primitive. It fails on the end of input or a token that cannot
 // begin a type.
-//
-//nolint:ireturn // types.Expression is the recursive node contract.
 func (p Parser) term() (types.Expression, error) {
 	node, ok := p.tokens.Take()
 	if !ok {

--- a/model/pipeline/unified/field.go
+++ b/model/pipeline/unified/field.go
@@ -33,8 +33,8 @@ func NewFieldMapping() FieldMapping {
 	return FieldMapping{}
 }
 
-// Apply implements [pipeline.Mapping]. It fails when the description carries the
-// "Optional" marker without its following ". " separator.
+// Apply implements [pipeline.Mapping]. It fails when the description carries
+// the "Optional" marker without its following ". " separator.
 func (m FieldMapping) Apply(field parsed.Field) (Field, error) {
 	description, optional, err := m.resolveDescription(field.Description)
 	if err != nil {
@@ -51,8 +51,8 @@ func (m FieldMapping) Apply(field parsed.Field) (Field, error) {
 // resolveDescription splits a field's description into its optionality and
 // normalized prose. A description that does not open with the italic "Optional"
 // marker belongs to a required field and rides through unchanged. One that does
-// is optional: the marker and the ". " separator that follows it are removed. It
-// fails when the marker is present but the ". " separator is not.
+// is optional: the marker and the ". " separator that follows it are removed.
+// It fails when the marker is present but the ". " separator is not.
 func (m FieldMapping) resolveDescription(
 	description prose.Phrase,
 ) (prose.Phrase, bool, error) {
@@ -102,7 +102,8 @@ func (m ParamMapping) Apply(param parsed.Param) (Field, error) {
 }
 
 // resolveRequired reads a parameter's Required column, yielding true when it
-// holds "Optional" and false when it holds "Yes". It fails on any other content.
+// holds "Optional" and false when it holds "Yes". It fails on any other
+// content.
 func (m ParamMapping) resolveRequired(required prose.Phrase) (bool, error) {
 	inlines := required.Inlines()
 	optional := prose.NewText("Optional", prose.StylePlain)

--- a/model/pipeline/unified/specification.go
+++ b/model/pipeline/unified/specification.go
@@ -13,7 +13,8 @@ import (
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 )
 
-// Fields is the table of unified fields, keyed by owner reference and field key.
+// Fields is the table of unified fields, keyed by owner reference and field
+// key.
 type Fields = pipeline.Table[model.FieldKey, Field]
 
 // Specification is the database after object fields and method parameters are

--- a/model/result/result.go
+++ b/model/result/result.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package result classifies what a Telegram Bot API method returns into one of
+// two variants: a [Confirmation] that only signals success, or a [Value] that
+// carries a typed return expression.
+package result
+
+import "github.com/andreychh/tgen/model/types/v2"
+
+// Result represents what a Telegram Bot API method returns. The concrete
+// variants are [Confirmation] and [Value].
+//
+//sumtype:decl
+type Result interface {
+	isResult()
+}
+
+// Confirmation represents a method result that only signals success.
+type Confirmation struct{}
+
+// NewConfirmation constructs a Confirmation.
+func NewConfirmation() Confirmation {
+	return Confirmation{}
+}
+
+func (Confirmation) isResult() {}
+
+// Value represents a method result that carries a typed return expression.
+type Value struct {
+	expr types.Expression
+}
+
+// NewValue constructs a Value from a return type expression.
+func NewValue(expr types.Expression) Value {
+	return Value{expr: expr}
+}
+
+// Type returns the return type expression carried by the Value.
+func (v Value) Type() types.Expression {
+	return v.expr
+}
+
+func (Value) isResult() {}


### PR DESCRIPTION
This PR adds the `resolved` pipeline stage, which decodes each method's return type from its description prose into a typed `result.Result`. The decoding is handled by `model/pipeline/resolved/types` — a rule-based parser that scans the method's first paragraph for known return clause forms (`Returns <type>`, `Array of <named>`, `<named> is returned, otherwise <primitive>`, and their union variant). The result is classified as either `Confirmation` (when the method returns only `True`) or `Value` (when it carries a typed expression), via the new `model/result` package.

`result.Result` lives in `model/result` rather than inside `resolved` because it is a shared domain type — analogous to `model/prose` — and will be consumed by downstream targets, not just the pipeline stage that produces it.

Closes #222