### PR TITLE
Add `Position` to `Field` across `parsed`, `unified`, `typed`

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -13,12 +13,11 @@ type Reference string
 
 type Optionality bool
 
-type Description interface {
-	Value() (string, error)
-	Links() ([]string, error)
-}
-
 type Key string
+
+// Position identifies a field's place among the other fields owned by the
+// same reference: zero-based, unique and gapless within that owner's fields.
+type Position int
 
 type DiscriminatorValue string
 
@@ -38,4 +37,9 @@ type FieldKey struct {
 type VariantKey struct {
 	Owner Reference
 	Ref   Reference
+}
+
+type Description interface {
+	Value() (string, error)
+	Links() ([]string, error)
 }

--- a/model/pipeline/parsed/field.go
+++ b/model/pipeline/parsed/field.go
@@ -14,28 +14,32 @@ import (
 	prosetree "github.com/andreychh/tgen/model/prose"
 )
 
-// Field is the decoded record of one object field: its key and the verbatim
-// prose of its type and description. Resolving the type and lifting optionality
-// are left for later passes.
+// Field is the decoded record of one object field: its key, its position
+// among the object's other fields, and the verbatim prose of its type and
+// description. Resolving the type and lifting optionality are left for later
+// passes.
 type Field struct {
 	Key         model.Key
+	Position    model.Position
 	Type        prosetree.Phrase
 	Description prosetree.Phrase
 }
 
-// FieldRow is one field's row of an object's table.
+// FieldRow is one field's row of an object's table, at its position among
+// sibling rows.
 type FieldRow struct {
+	at int
 	tr *goquery.Selection
 }
 
-// NewFieldRow constructs a FieldRow over a table row.
-func NewFieldRow(tr *goquery.Selection) FieldRow {
-	return FieldRow{tr: tr}
+// NewFieldRow constructs a FieldRow over a table row at position at.
+func NewFieldRow(at int, tr *goquery.Selection) FieldRow {
+	return FieldRow{at: at, tr: tr}
 }
 
-// Record returns the field decoded from the row: its key and the prose of its
-// type and description. It fails when the key, type, or description is
-// malformed.
+// Record returns the field decoded from the row: its key, its position, and
+// the prose of its type and description. It fails when the key, type, or
+// description is malformed.
 func (r FieldRow) Record() (Field, error) {
 	key, err := NewKey(r.cell(0)).Value()
 	if err != nil {
@@ -51,6 +55,7 @@ func (r FieldRow) Record() (Field, error) {
 	}
 	return Field{
 		Key:         key,
+		Position:    model.Position(r.at),
 		Type:        typ,
 		Description: description,
 	}, nil
@@ -79,8 +84,8 @@ func (f ObjectFields) Records() (model.Reference, []Field, error) {
 	}
 	var fields []Field
 	rows := f.h4.NextUntil("h3, h4, hr").Filter("table.table").First().Find("tbody > tr")
-	for _, tr := range rows.EachIter() {
-		field, err := NewFieldRow(tr).Record()
+	for at, tr := range rows.EachIter() {
+		field, err := NewFieldRow(at, tr).Record()
 		if err != nil {
 			return "", nil, fmt.Errorf("parsing field: %w", err)
 		}

--- a/model/pipeline/parsed/param.go
+++ b/model/pipeline/parsed/param.go
@@ -14,29 +14,33 @@ import (
 	prosetree "github.com/andreychh/tgen/model/prose"
 )
 
-// Param is the decoded record of one method parameter: its key and the verbatim
-// prose of its type, requiredness, and description. Lifting optionality is left
-// for a later pass, as with object fields.
+// Param is the decoded record of one method parameter: its key, its position
+// among the method's other parameters, and the verbatim prose of its type,
+// requiredness, and description. Lifting optionality is left for a later
+// pass, as with object fields.
 type Param struct {
 	Key         model.Key
+	Position    model.Position
 	Type        prosetree.Phrase
 	Required    prosetree.Phrase
 	Description prosetree.Phrase
 }
 
-// ParamRow is one parameter's row of a method's table.
+// ParamRow is one parameter's row of a method's table, at its position among
+// sibling rows.
 type ParamRow struct {
+	at int
 	tr *goquery.Selection
 }
 
-// NewParamRow constructs a ParamRow over a table row.
-func NewParamRow(tr *goquery.Selection) ParamRow {
-	return ParamRow{tr: tr}
+// NewParamRow constructs a ParamRow over a table row at position at.
+func NewParamRow(at int, tr *goquery.Selection) ParamRow {
+	return ParamRow{at: at, tr: tr}
 }
 
-// Record returns the parameter decoded from the row: its key and the prose of
-// its type, requiredness, and description. It fails when the key, type,
-// requiredness, or description is malformed.
+// Record returns the parameter decoded from the row: its key, its position,
+// and the prose of its type, requiredness, and description. It fails when the
+// key, type, requiredness, or description is malformed.
 func (r ParamRow) Record() (Param, error) {
 	key, err := NewKey(r.cell(0)).Value()
 	if err != nil {
@@ -56,6 +60,7 @@ func (r ParamRow) Record() (Param, error) {
 	}
 	return Param{
 		Key:         key,
+		Position:    model.Position(r.at),
 		Type:        typ,
 		Required:    required,
 		Description: description,
@@ -86,8 +91,8 @@ func (p MethodParams) Records() (model.Reference, []Param, error) {
 	}
 	var params []Param
 	rows := p.h4.NextUntil("h3, h4, hr").Filter("table.table").First().Find("tbody > tr")
-	for _, tr := range rows.EachIter() {
-		param, err := NewParamRow(tr).Record()
+	for at, tr := range rows.EachIter() {
+		param, err := NewParamRow(at, tr).Record()
 		if err != nil {
 			return "", nil, fmt.Errorf("parsing parameter: %w", err)
 		}

--- a/model/pipeline/typed/field.go
+++ b/model/pipeline/typed/field.go
@@ -14,10 +14,11 @@ import (
 )
 
 // Field is a field of an object or a parameter of a method whose type is
-// resolved from prose into a type expression. Its key, optionality, and
-// description carry over from the unified stage.
+// resolved from prose into a type expression. Its key, position, optionality,
+// and description carry over from the unified stage.
 type Field struct {
 	Key         model.Key
+	Position    model.Position
 	Type        typetree.Expression
 	Optionality model.Optionality
 	Description prose.Phrase
@@ -41,6 +42,7 @@ func (m FieldMapping) Apply(field unified.Field) (Field, error) {
 	}
 	return Field{
 		Key:         field.Key,
+		Position:    field.Position,
 		Type:        expr,
 		Optionality: field.Optionality,
 		Description: field.Description,

--- a/model/pipeline/unified/field.go
+++ b/model/pipeline/unified/field.go
@@ -13,10 +13,12 @@ import (
 )
 
 // Field is a field of an object or a parameter of a method, reduced to a single
-// shape: its key, the verbatim prose of its type, whether it is optional, and
-// its description with the optional marker removed.
+// shape: its key, its position among its owner's other fields, the verbatim
+// prose of its type, whether it is optional, and its description with the
+// optional marker removed.
 type Field struct {
 	Key         model.Key
+	Position    model.Position
 	Type        prose.Phrase
 	Optionality model.Optionality
 	Description prose.Phrase
@@ -42,6 +44,7 @@ func (m FieldMapping) Apply(field parsed.Field) (Field, error) {
 	}
 	return Field{
 		Key:         field.Key,
+		Position:    field.Position,
 		Type:        field.Type,
 		Optionality: model.Optionality(optional),
 		Description: description,
@@ -95,6 +98,7 @@ func (m ParamMapping) Apply(param parsed.Param) (Field, error) {
 	}
 	return Field{
 		Key:         param.Key,
+		Position:    param.Position,
 		Type:        param.Type,
 		Optionality: model.Optionality(optional),
 		Description: param.Description,


### PR DESCRIPTION
This PR adds `model.Position` and threads it through the `parsed`, `unified`, and `typed` pipeline stages: `parsed.Field`/`parsed.Param` capture a row's index while parsing its table, and `unified.FieldMapping`/`typed.FieldMapping` carry it through unchanged.

`Position` is a plain type with no validating constructor — its zero-based, unique, gapless invariant is already guaranteed by its only source, the index from ranging over a table's rows, so nothing can construct an invalid one.

Closes #225