### PR TITLE
Add a `classified` pass producing a `Discriminators` table

### DIFF
--- a/model/pipeline/classified/discriminator.go
+++ b/model/pipeline/classified/discriminator.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package classified
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/classified/discriminator"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+)
+
+// Discriminator is the fixed value a field's description decodes for the
+// reference that owns it.
+type Discriminator struct {
+	// Key is the field that carries the fixed value.
+	Key   model.Key
+	Value model.DiscriminatorValue
+}
+
+// DiscriminatorTable is the extraction operator: it decodes every field at
+// position zero for the fixed discriminator value its description may carry,
+// keyed by the reference of the field's owner.
+type DiscriminatorTable struct {
+	fields typed.Fields
+}
+
+// NewDiscriminatorTable constructs a DiscriminatorTable over fields.
+func NewDiscriminatorTable(fields typed.Fields) DiscriminatorTable {
+	return DiscriminatorTable{fields: fields}
+}
+
+// Apply returns the discriminators table, one record per field at position
+// zero whose description decodes a fixed discriminator value, keyed by the
+// reference of the field's owner.
+func (t DiscriminatorTable) Apply() Discriminators {
+	out := pipeline.NewMapTable[model.Reference, Discriminator]()
+	for key, field := range t.fields.All() {
+		if field.Position != 0 {
+			continue
+		}
+		value, ok := discriminator.NewLabel(field.Description).Value()
+		if !ok {
+			continue
+		}
+		out.Insert(key.Owner, Discriminator{Key: field.Key, Value: value})
+	}
+	return out
+}

--- a/model/pipeline/classified/discriminator/label.go
+++ b/model/pipeline/classified/discriminator/label.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package discriminator decodes the prose of a field's description into the
+// fixed discriminator value it may carry.
+//
+// [Label] is the entry point: wrap a field's description and call its Value
+// method. Decoding is driven by [Rule] implementations — [AlwaysRule] and
+// [MustBeRule] — each recognizing one structural form a discriminator value
+// takes; [ProductionRule] tries them in order. A description matching neither
+// rule is not a label, which Value reports rather than treats as failure.
+package discriminator
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// Label is a field's description ready to be decoded into the fixed
+// discriminator value it may carry.
+type Label struct {
+	description prose.Phrase
+}
+
+// NewLabel constructs a Label over a field's description.
+func NewLabel(description prose.Phrase) Label {
+	return Label{description: description}
+}
+
+// Value returns the discriminator value decoded from the description, and
+// reports whether the description carries one.
+func (l Label) Value() (model.DiscriminatorValue, bool) {
+	return rules().Match(l.description.Inlines())
+}
+
+// rules assembles the discriminator production in priority order.
+func rules() ProductionRule {
+	return NewProductionRule(NewAlwaysRule(), NewMustBeRule())
+}

--- a/model/pipeline/classified/discriminator/production.go
+++ b/model/pipeline/classified/discriminator/production.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package discriminator
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// ProductionRule is a [Rule] composed of other rules tried in priority order.
+type ProductionRule struct {
+	rules []Rule
+}
+
+// NewProductionRule constructs a ProductionRule from its rules, in priority
+// order.
+func NewProductionRule(rules ...Rule) ProductionRule {
+	return ProductionRule{rules: rules}
+}
+
+// Match implements [Rule].
+func (p ProductionRule) Match(inlines []prose.Inline) (model.DiscriminatorValue, bool) {
+	for _, rule := range p.rules {
+		if value, ok := rule.Match(inlines); ok {
+			return value, true
+		}
+	}
+	return "", false
+}

--- a/model/pipeline/classified/discriminator/rule.go
+++ b/model/pipeline/classified/discriminator/rule.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package discriminator
+
+import (
+	"regexp"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+var (
+	alwaysSignal = regexp.MustCompile(`(?i)\balways\s*“([^”]+)”\s*$`)
+	mustBeSignal = regexp.MustCompile(`(?i)\bmust be\s*$`)
+)
+
+// Rule is a pattern that recognizes one structural form of a fixed
+// discriminator value inside a field's description, decoding it into the value
+// it names.
+type Rule interface {
+	// Match reports whether the rule's form matches the front of inlines and
+	// returns the discriminator value it names.
+	Match(inlines []prose.Inline) (model.DiscriminatorValue, bool)
+}
+
+// AlwaysRule is a [Rule] that recognizes "…, always “value”", a fixed value
+// quoted inside a single plain text run.
+type AlwaysRule struct{}
+
+// NewAlwaysRule constructs an AlwaysRule.
+func NewAlwaysRule() AlwaysRule {
+	return AlwaysRule{}
+}
+
+// Match implements [Rule].
+func (AlwaysRule) Match(inlines []prose.Inline) (model.DiscriminatorValue, bool) {
+	if len(inlines) < 1 {
+		return "", false
+	}
+	text, ok := inlines[0].(prose.Text)
+	if !ok || text.Style() != prose.StylePlain {
+		return "", false
+	}
+	match := alwaysSignal.FindStringSubmatch(text.Content())
+	if match == nil {
+		return "", false
+	}
+	return model.DiscriminatorValue(match[1]), true
+}
+
+// MustBeRule is a [Rule] that recognizes "…, must be <value>", a fixed value
+// carried by a trailing italic run.
+type MustBeRule struct{}
+
+// NewMustBeRule constructs a MustBeRule.
+func NewMustBeRule() MustBeRule {
+	return MustBeRule{}
+}
+
+// Match implements [Rule].
+func (MustBeRule) Match(inlines []prose.Inline) (model.DiscriminatorValue, bool) {
+	if len(inlines) < 2 {
+		return "", false
+	}
+	lead, ok := inlines[0].(prose.Text)
+	if !ok || lead.Style() != prose.StylePlain || !mustBeSignal.MatchString(lead.Content()) {
+		return "", false
+	}
+	value, ok := inlines[1].(prose.Text)
+	if !ok || value.Style() != prose.StyleItalic {
+		return "", false
+	}
+	return model.DiscriminatorValue(value.Content()), true
+}

--- a/model/pipeline/classified/field.go
+++ b/model/pipeline/classified/field.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package classified
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+)
+
+// Field is a classified field, an alias of [typed.Field]: the classified
+// stage changes which fields belong to Fields, not the shape of any single
+// field.
+type Field = typed.Field
+
+// FieldFilter is a [pipeline.Filter] that excludes a field already extracted
+// into discriminators.
+type FieldFilter struct {
+	discriminators Discriminators
+}
+
+// NewFieldFilter constructs a FieldFilter over the discriminators already
+// extracted from Fields.
+func NewFieldFilter(discriminators Discriminators) FieldFilter {
+	return FieldFilter{discriminators: discriminators}
+}
+
+// Apply implements [pipeline.Filter]. It reports whether field belongs in
+// the filtered result: false when its owner already carries a discriminator
+// under field's own key.
+func (f FieldFilter) Apply(key model.FieldKey, field Field) bool {
+	record, exists := f.discriminators.Lookup(key.Owner)
+	return !exists || record.Key != key.Key
+}

--- a/model/pipeline/classified/specification.go
+++ b/model/pipeline/classified/specification.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package classified decodes the fixed discriminator value each field's
+// description may carry, moving it out of Fields into its own table.
+package classified
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/resolved"
+)
+
+// Fields is the table of classified fields, keyed by owner reference and
+// field key: every field whose description decodes a fixed discriminator
+// value is excluded.
+type Fields = pipeline.Table[model.FieldKey, Field]
+
+// Discriminators is the table of fixed discriminator values decoded out of
+// field descriptions, keyed by the reference of the field's owner.
+type Discriminators = pipeline.Table[model.Reference, Discriminator]
+
+// Specification is the database after every field's description is decoded
+// for the fixed discriminator value it may carry: a field that decodes one
+// moves from Fields into Discriminators. The object, method, union, and
+// variant tables and the release ride through from the resolved stage
+// unchanged.
+type Specification struct {
+	Objects        parsed.Objects
+	Methods        resolved.Methods
+	Fields         Fields
+	Discriminators Discriminators
+	Unions         parsed.Unions
+	Variants       parsed.Variants
+	Release        parsed.Release
+}
+
+// Pass is the classification stage: it rewrites a resolved specification into
+// a classified one, moving each field whose description decodes a fixed
+// discriminator value out of Fields and into Discriminators.
+type Pass struct {
+	spec resolved.Specification
+}
+
+// NewPass constructs a Pass over a resolved specification.
+func NewPass(spec resolved.Specification) Pass {
+	return Pass{spec: spec}
+}
+
+// Specification returns the classified specification, moving each field whose
+// description decodes a fixed discriminator value out of Fields and into
+// Discriminators.
+func (p Pass) Specification() Specification {
+	discriminators := NewDiscriminatorTable(p.spec.Fields).Apply()
+	fields := pipeline.NewFilteredTable(p.spec.Fields, NewFieldFilter(discriminators)).Apply()
+	return Specification{
+		Objects:        p.spec.Objects,
+		Methods:        p.spec.Methods,
+		Fields:         fields,
+		Discriminators: discriminators,
+		Unions:         p.spec.Unions,
+		Variants:       p.spec.Variants,
+		Release:        p.spec.Release,
+	}
+}

--- a/model/pipeline/operator.go
+++ b/model/pipeline/operator.go
@@ -48,6 +48,83 @@ func (t MappedTable[K, A, B]) Apply() (Table[K, B], error) {
 	return out, nil
 }
 
+// PartialMapping transforms one record into another, or reports that no
+// record results. It fails when the record cannot be evaluated.
+type PartialMapping[A, B Record] interface {
+	Apply(record A) (B, bool, error)
+}
+
+// PartialMappedTable is the filter-projection operator: it applies a partial
+// mapping to every record of a source table, keeping only the records for
+// which the mapping produces one, and carrying each kept record's key through
+// unchanged.
+type PartialMappedTable[K comparable, A, B Record] struct {
+	source  Table[K, A]
+	mapping PartialMapping[A, B]
+}
+
+// NewPartialMappedTable constructs the filtered projection of source through
+// mapping.
+func NewPartialMappedTable[K comparable, A, B Record](
+	source Table[K, A], mapping PartialMapping[A, B],
+) PartialMappedTable[K, A, B] {
+	return PartialMappedTable[K, A, B]{source: source, mapping: mapping}
+}
+
+// Apply returns the projected table, one record per source record for which
+// mapping produced one, under the same key. It fails when the mapping fails on
+// any record.
+func (t PartialMappedTable[K, A, B]) Apply() (Table[K, B], error) {
+	out := NewMapTableWithCapacity[K, B](t.source.Count())
+	for key, record := range t.source.All() {
+		mapped, ok, err := t.mapping.Apply(record)
+		if err != nil {
+			return out, fmt.Errorf("mapping record %v: %w", key, err)
+		}
+		if !ok {
+			continue
+		}
+		out.Insert(key, mapped)
+	}
+	return out, nil
+}
+
+// Filter decides whether a record, held under key, belongs in a filtered
+// table. It never fails: every key and record combination yields a definite
+// yes or no.
+type Filter[K comparable, R Record] interface {
+	Apply(key K, record R) bool
+}
+
+// FilteredTable is the restriction operator: it keeps every record of source
+// for which filter reports true, discarding the rest under their original
+// keys.
+type FilteredTable[K comparable, R Record] struct {
+	source Table[K, R]
+	filter Filter[K, R]
+}
+
+// NewFilteredTable constructs the restriction of source to the records filter
+// keeps.
+func NewFilteredTable[K comparable, R Record](
+	source Table[K, R], filter Filter[K, R],
+) FilteredTable[K, R] {
+	return FilteredTable[K, R]{source: source, filter: filter}
+}
+
+// Apply returns the restriction of source to the records filter keeps, one
+// per kept record under its original key.
+func (t FilteredTable[K, R]) Apply() Table[K, R] {
+	out := NewMapTableWithCapacity[K, R](t.source.Count())
+	for key, record := range t.source.All() {
+		if !t.filter.Apply(key, record) {
+			continue
+		}
+		out.Insert(key, record)
+	}
+	return out
+}
+
 // MergedTable is the union operator: it gathers every record from two tables
 // whose key sets are disjoint.
 type MergedTable[K comparable, R Record] struct {


### PR DESCRIPTION
This PR adds a `classified` pipeline pass that decodes each field's fixed discriminator value out of its description into a new `Discriminators` table, and removes that field from `Fields` so only genuine data fields remain there.

Filtering `Fields` needed the field's owner reference — the key it's stored under, not part of the record itself — which the existing `Mapping`/`PartialMapping` operators don't expose, so this PR adds a `Filter`/`FilteredTable` operator pair to `pipeline` that does.

Closes #229