### PR TITLE
Add a `modified` pass applying tgen's own type corrections

### DIFF
--- a/model/pipeline/modified/alias.go
+++ b/model/pipeline/modified/alias.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+// Alias is a name tgen introduces for a type expression the documentation
+// leaves unnamed. Its description is tgen's own, since the documentation has
+// none for a type it never names.
+type Alias struct {
+	Ref         model.Reference
+	Name        model.Name
+	Type        typetree.Expression
+	Description prose.Passage
+}

--- a/model/pipeline/modified/chat_id.go
+++ b/model/pipeline/modified/chat_id.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+	"github.com/andreychh/tgen/model/prose"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+const (
+	chatIDRef   = model.Reference("chatid")
+	idRef       = model.Reference("id")
+	usernameRef = model.Reference("username")
+)
+
+// ChatID is a [Rule] that introduces the ChatID union — a chat addressed by
+// numeric ID or by username — and redirects every Integer-or-String field to
+// it.
+type ChatID struct{}
+
+// Apply implements [Rule]. It fails when chatid, id, or username already
+// names something else in spec.
+func (r ChatID) Apply(spec Specification) (Specification, error) {
+	for _, ref := range []model.Reference{chatIDRef, idRef, usernameRef} {
+		if alreadyExists(spec, ref) {
+			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
+		}
+	}
+	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing chat id aliases: %w", err)
+	}
+	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing chat id union: %w", err)
+	}
+	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing chat id variants: %w", err)
+	}
+	fields, err := pipeline.NewMappedTable(spec.Fields, chatIDMapping{}).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("redirecting chat id fields: %w", err)
+	}
+	return Specification{
+		Objects:  spec.Objects,
+		Methods:  spec.Methods,
+		Fields:   fields,
+		Unions:   unions,
+		Variants: variants,
+		Aliases:  aliases,
+		Release:  spec.Release,
+	}, nil
+}
+
+// aliases returns the table of primitive aliases ChatID's variants need: a
+// numeric id and a username, neither of which the documentation names.
+func (r ChatID) aliases() Aliases {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](2)
+	out.Insert(idRef, Alias{
+		Ref:  idRef,
+		Name: "Id",
+		Type: typetree.NewPrimitive(typetree.Integer),
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"ID represents a numeric Telegram chat or user identifier.",
+			prose.StylePlain,
+		))),
+	})
+	out.Insert(usernameRef, Alias{
+		Ref:  usernameRef,
+		Name: "Username",
+		Type: typetree.NewPrimitive(typetree.String),
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"Username represents a Telegram username.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// union returns the table holding the single ChatID union definition.
+func (r ChatID) union() parsed.Unions {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
+	out.Insert(chatIDRef, parsed.Union{
+		Ref:  chatIDRef,
+		Name: "ChatId",
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"ChatId represents a chat identifier, either a numeric ID or a username.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// variants returns the table of ChatID's two variants, id and username.
+func (r ChatID) variants() parsed.Variants {
+	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](2)
+	out.Insert(
+		model.VariantKey{Owner: chatIDRef, Ref: idRef},
+		parsed.Variant{Ref: idRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: chatIDRef, Ref: usernameRef},
+		parsed.Variant{Ref: usernameRef},
+	)
+	return out
+}
+
+// chatIDMapping is a [pipeline.Mapping] that redirects a field typed as
+// Integer or String to the ChatID union; every other field rides through
+// unchanged.
+type chatIDMapping struct{}
+
+// Apply implements [pipeline.Mapping]. It never fails.
+func (chatIDMapping) Apply(field typed.Field) (typed.Field, error) {
+	if !field.Type.Equals(typetree.NewUnion(
+		typetree.NewPrimitive(typetree.Integer),
+		typetree.NewPrimitive(typetree.String),
+	)) {
+		return field, nil
+	}
+	return typed.Field{
+		Key:         field.Key,
+		Position:    field.Position,
+		Type:        typetree.NewNamed(chatIDRef),
+		Optionality: field.Optionality,
+		Description: field.Description,
+	}, nil
+}

--- a/model/pipeline/modified/input_file.go
+++ b/model/pipeline/modified/input_file.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+	"github.com/andreychh/tgen/model/prose"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+const (
+	inputFileRef = model.Reference("inputfile")
+	fileIDRef    = model.Reference("fileid")
+	uploadRef    = model.Reference("upload")
+)
+
+// InputFile is a [Rule] that introduces the InputFile union — a file to
+// send, either by file ID or by uploading — in place of the documented
+// InputFile object, and redirects every field that could carry one to it.
+type InputFile struct{}
+
+// Apply implements [Rule]. It fails when fileid or upload already names
+// something else in spec.
+func (r InputFile) Apply(spec Specification) (Specification, error) {
+	for _, ref := range []model.Reference{fileIDRef, uploadRef} {
+		if alreadyExists(spec, ref) {
+			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
+		}
+	}
+	objects := pipeline.NewFilteredTable(spec.Objects, inputFileFilter{}).Apply()
+	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input file aliases: %w", err)
+	}
+	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input file union: %w", err)
+	}
+	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input file variants: %w", err)
+	}
+	fields, err := pipeline.NewMappedTable(spec.Fields, inputFileMapping{}).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("redirecting input file fields: %w", err)
+	}
+	return Specification{
+		Objects:  objects,
+		Methods:  spec.Methods,
+		Fields:   fields,
+		Unions:   unions,
+		Variants: variants,
+		Aliases:  aliases,
+		Release:  spec.Release,
+	}, nil
+}
+
+// aliases returns the table of primitive aliases InputFile's variants need:
+// a file id, which the documentation writes as a plain String field, not a
+// named type.
+func (r InputFile) aliases() Aliases {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](1)
+	out.Insert(fileIDRef, Alias{
+		Ref:  fileIDRef,
+		Name: "FileId",
+		Type: typetree.NewPrimitive(typetree.String),
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"FileID represents a Telegram file identifier.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// union returns the table holding the single InputFile union definition.
+func (r InputFile) union() parsed.Unions {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
+	out.Insert(inputFileRef, parsed.Union{
+		Ref:  inputFileRef,
+		Name: "InputFile",
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"InputFile represents a file to send, either by file ID or by uploading.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// variants returns the table of InputFile's variants. It carries only
+// FileId: the upload variant holds a Go io.Reader with no shape shared
+// across targets, so it still needs its own design before it can join this
+// table.
+func (r InputFile) variants() parsed.Variants {
+	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](1)
+	out.Insert(
+		model.VariantKey{Owner: inputFileRef, Ref: fileIDRef},
+		parsed.Variant{Ref: fileIDRef},
+	)
+	return out
+}
+
+// inputFileFilter is a [pipeline.Filter] that excludes the documented InputFile
+// object from Objects.
+type inputFileFilter struct{}
+
+// Apply implements [pipeline.Filter]. It reports whether object belongs in the
+// filtered result: false when ref is inputfile.
+func (inputFileFilter) Apply(ref model.Reference, object parsed.Object) bool {
+	return ref != inputFileRef
+}
+
+// inputFileMapping is a [pipeline.Mapping] that redirects a field that could
+// carry an InputFile to InputFile; every other field rides through
+// unchanged.
+type inputFileMapping struct{}
+
+// Apply implements [pipeline.Mapping]. It never fails.
+func (m inputFileMapping) Apply(field typed.Field) (typed.Field, error) {
+	if !m.matches(field) {
+		return field, nil
+	}
+	return typed.Field{
+		Key:         field.Key,
+		Position:    field.Position,
+		Type:        typetree.NewNamed(inputFileRef),
+		Optionality: field.Optionality,
+		Description: field.Description,
+	}, nil
+}
+
+// matches reports whether field is typed as InputFile alone, as InputFile or
+// String, or as a bare String field whose description links to the
+// sending-files guide.
+func (m inputFileMapping) matches(field typed.Field) bool {
+	return field.Type.Equals(typetree.NewNamed(inputFileRef)) ||
+		field.Type.Equals(typetree.NewUnion(
+			typetree.NewNamed(inputFileRef),
+			typetree.NewPrimitive(typetree.String),
+		)) ||
+		field.Type.Equals(typetree.NewPrimitive(typetree.String)) &&
+			hasSendingFilesLink(field.Description)
+}
+
+// hasSendingFilesLink reports whether description links to the sending-files
+// guide section.
+func hasSendingFilesLink(description prose.Phrase) bool {
+	for _, inline := range description.Inlines() {
+		link, ok := inline.(prose.Link)
+		if !ok {
+			continue
+		}
+		anchor, isAnchor := link.Anchor()
+		if isAnchor && anchor == "sending-files" {
+			return true
+		}
+	}
+	return false
+}

--- a/model/pipeline/modified/input_media_group.go
+++ b/model/pipeline/modified/input_media_group.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+	"github.com/andreychh/tgen/model/prose"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+const (
+	inputMediaGroupRef     = model.Reference("inputmediagroup")
+	inputMediaDocumentRef  = model.Reference("inputmediadocument")
+	inputMediaLivePhotoRef = model.Reference("inputmedialivephoto")
+)
+
+// InputMediaGroup is a [Rule] that introduces the InputMediaGroup union — a
+// media element in a media group — and redirects every field typed as an
+// array of their union to an array of it.
+type InputMediaGroup struct{}
+
+// Apply implements [Rule]. It fails when inputmediagroup already names
+// something else in spec.
+func (r InputMediaGroup) Apply(spec Specification) (Specification, error) {
+	if alreadyExists(spec, inputMediaGroupRef) {
+		return Specification{}, fmt.Errorf(
+			"%s already names something else in spec",
+			inputMediaGroupRef,
+		)
+	}
+	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input media group union: %w", err)
+	}
+	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input media group variants: %w", err)
+	}
+	fields, err := pipeline.NewMappedTable(spec.Fields, inputMediaGroupMapping{}).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("redirecting input media group fields: %w", err)
+	}
+	return Specification{
+		Objects:  spec.Objects,
+		Methods:  spec.Methods,
+		Fields:   fields,
+		Unions:   unions,
+		Variants: variants,
+		Aliases:  spec.Aliases,
+		Release:  spec.Release,
+	}, nil
+}
+
+// union returns the table holding the single InputMediaGroup union
+// definition.
+func (r InputMediaGroup) union() parsed.Unions {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
+	out.Insert(inputMediaGroupRef, parsed.Union{
+		Ref:  inputMediaGroupRef,
+		Name: "InputMediaGroup",
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"InputMediaGroup represents a media element in a media group.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// variants returns the table of InputMediaGroup's five variants, each
+// already a documented object.
+func (r InputMediaGroup) variants() parsed.Variants {
+	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](5)
+	out.Insert(
+		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaAudioRef},
+		parsed.Variant{Ref: inputMediaAudioRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaDocumentRef},
+		parsed.Variant{Ref: inputMediaDocumentRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaLivePhotoRef},
+		parsed.Variant{Ref: inputMediaLivePhotoRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaPhotoRef},
+		parsed.Variant{Ref: inputMediaPhotoRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaVideoRef},
+		parsed.Variant{Ref: inputMediaVideoRef},
+	)
+	return out
+}
+
+// inputMediaGroupMapping is a [pipeline.Mapping] that redirects a field
+// typed as an array of the five-variant input media union to an array of
+// InputMediaGroup; every other field rides through unchanged.
+type inputMediaGroupMapping struct{}
+
+// Apply implements [pipeline.Mapping]. It never fails.
+func (inputMediaGroupMapping) Apply(field typed.Field) (typed.Field, error) {
+	if !field.Type.Equals(typetree.NewArray(typetree.NewUnion(
+		typetree.NewNamed(inputMediaAudioRef),
+		typetree.NewNamed(inputMediaDocumentRef),
+		typetree.NewNamed(inputMediaLivePhotoRef),
+		typetree.NewNamed(inputMediaPhotoRef),
+		typetree.NewNamed(inputMediaVideoRef),
+	))) {
+		return field, nil
+	}
+	return typed.Field{
+		Key:         field.Key,
+		Position:    field.Position,
+		Type:        typetree.NewArray(typetree.NewNamed(inputMediaGroupRef)),
+		Optionality: field.Optionality,
+		Description: field.Description,
+	}, nil
+}

--- a/model/pipeline/modified/input_rich_media.go
+++ b/model/pipeline/modified/input_rich_media.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+	"github.com/andreychh/tgen/model/prose"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+const (
+	inputRichMediaRef      = model.Reference("inputrichmedia")
+	inputMediaAnimationRef = model.Reference("inputmediaanimation")
+	inputMediaAudioRef     = model.Reference("inputmediaaudio")
+	inputMediaPhotoRef     = model.Reference("inputmediaphoto")
+	inputMediaVideoRef     = model.Reference("inputmediavideo")
+	inputMediaVoiceNoteRef = model.Reference("inputmediavoicenote")
+)
+
+// InputRichMedia is a [Rule] that introduces the InputRichMedia union — a
+// media element embedded in a rich message — and redirects every field
+// typed as their union to it.
+type InputRichMedia struct{}
+
+// Apply implements [Rule]. It fails when inputrichmedia already names
+// something else in spec.
+func (r InputRichMedia) Apply(spec Specification) (Specification, error) {
+	if alreadyExists(spec, inputRichMediaRef) {
+		return Specification{}, fmt.Errorf(
+			"%s already names something else in spec",
+			inputRichMediaRef,
+		)
+	}
+	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input rich media union: %w", err)
+	}
+	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input rich media variants: %w", err)
+	}
+	fields, err := pipeline.NewMappedTable(spec.Fields, inputRichMediaMapping{}).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("redirecting input rich media fields: %w", err)
+	}
+	return Specification{
+		Objects:  spec.Objects,
+		Methods:  spec.Methods,
+		Fields:   fields,
+		Unions:   unions,
+		Variants: variants,
+		Aliases:  spec.Aliases,
+		Release:  spec.Release,
+	}, nil
+}
+
+// union returns the table holding the single InputRichMedia union
+// definition.
+func (r InputRichMedia) union() parsed.Unions {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
+	out.Insert(inputRichMediaRef, parsed.Union{
+		Ref:  inputRichMediaRef,
+		Name: "InputRichMedia",
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"InputRichMedia represents a media element embedded in a rich message.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// variants returns the table of InputRichMedia's five variants, each
+// already a documented object.
+func (r InputRichMedia) variants() parsed.Variants {
+	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](5)
+	out.Insert(
+		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaAnimationRef},
+		parsed.Variant{Ref: inputMediaAnimationRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaAudioRef},
+		parsed.Variant{Ref: inputMediaAudioRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaPhotoRef},
+		parsed.Variant{Ref: inputMediaPhotoRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaVideoRef},
+		parsed.Variant{Ref: inputMediaVideoRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaVoiceNoteRef},
+		parsed.Variant{Ref: inputMediaVoiceNoteRef},
+	)
+	return out
+}
+
+// inputRichMediaMapping is a [pipeline.Mapping] that redirects a field
+// typed as the five-variant input rich media union to InputRichMedia; every
+// other field rides through unchanged.
+type inputRichMediaMapping struct{}
+
+// Apply implements [pipeline.Mapping]. It never fails.
+func (inputRichMediaMapping) Apply(field typed.Field) (typed.Field, error) {
+	if !field.Type.Equals(typetree.NewUnion(
+		typetree.NewNamed(inputMediaAnimationRef),
+		typetree.NewNamed(inputMediaAudioRef),
+		typetree.NewNamed(inputMediaPhotoRef),
+		typetree.NewNamed(inputMediaVideoRef),
+		typetree.NewNamed(inputMediaVoiceNoteRef),
+	)) {
+		return field, nil
+	}
+	return typed.Field{
+		Key:         field.Key,
+		Position:    field.Position,
+		Type:        typetree.NewNamed(inputRichMediaRef),
+		Optionality: field.Optionality,
+		Description: field.Description,
+	}, nil
+}

--- a/model/pipeline/modified/maybe_message.go
+++ b/model/pipeline/modified/maybe_message.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/resolved"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/result"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+const (
+	maybeMessageRef = model.Reference("maybemessage")
+	messageRef      = model.Reference("message")
+	trueRef         = model.Reference("true")
+)
+
+// MaybeMessage is a [Rule] that introduces the MaybeMessage union — a method
+// return value that is either an edited Message or True for inline
+// messages — and redirects every method returning their union to it.
+type MaybeMessage struct{}
+
+// Apply implements [Rule]. It fails when maybemessage or true already names
+// something else in spec.
+func (r MaybeMessage) Apply(spec Specification) (Specification, error) {
+	for _, ref := range []model.Reference{maybeMessageRef, trueRef} {
+		if alreadyExists(spec, ref) {
+			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
+		}
+	}
+	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing maybe message aliases: %w", err)
+	}
+	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing maybe message union: %w", err)
+	}
+	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing maybe message variants: %w", err)
+	}
+	methods, err := pipeline.NewMappedTable(spec.Methods, maybeMessageMapping{}).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("redirecting maybe message methods: %w", err)
+	}
+	return Specification{
+		Objects:  spec.Objects,
+		Methods:  methods,
+		Fields:   spec.Fields,
+		Unions:   unions,
+		Variants: variants,
+		Aliases:  aliases,
+		Release:  spec.Release,
+	}, nil
+}
+
+// aliases returns the table of primitive aliases MaybeMessage's variants
+// need: True, which the documentation writes as a bare keyword, not a named
+// type.
+func (r MaybeMessage) aliases() Aliases {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](1)
+	out.Insert(trueRef, Alias{
+		Ref:  trueRef,
+		Name: "True",
+		Type: typetree.NewPrimitive(typetree.True),
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"True represents the boolean true value in Telegram API responses.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// union returns the table holding the single MaybeMessage union definition.
+func (r MaybeMessage) union() parsed.Unions {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
+	out.Insert(maybeMessageRef, parsed.Union{
+		Ref:  maybeMessageRef,
+		Name: "MaybeMessage",
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"MaybeMessage represents a method return value that is either an "+
+				"edited Message or True for inline messages.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// variants returns the table of MaybeMessage's two variants, message and
+// true.
+func (r MaybeMessage) variants() parsed.Variants {
+	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](2)
+	out.Insert(
+		model.VariantKey{Owner: maybeMessageRef, Ref: messageRef},
+		parsed.Variant{Ref: messageRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: maybeMessageRef, Ref: trueRef},
+		parsed.Variant{Ref: trueRef},
+	)
+	return out
+}
+
+// maybeMessageMapping is a [pipeline.Mapping] that redirects a method
+// returning the Message-or-True union to MaybeMessage; every other method
+// rides through unchanged.
+type maybeMessageMapping struct{}
+
+// Apply implements [pipeline.Mapping]. It never fails.
+func (maybeMessageMapping) Apply(method resolved.Method) (resolved.Method, error) {
+	value, ok := method.Result.(result.Value)
+	if !ok {
+		return method, nil
+	}
+	if !value.Type().Equals(typetree.NewUnion(
+		typetree.NewNamed(messageRef),
+		typetree.NewPrimitive(typetree.True),
+	)) {
+		return method, nil
+	}
+	return resolved.Method{
+		Ref:    method.Ref,
+		Name:   method.Name,
+		Result: result.NewValue(typetree.NewNamed(maybeMessageRef)),
+	}, nil
+}

--- a/model/pipeline/modified/reply_markup.go
+++ b/model/pipeline/modified/reply_markup.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+	"github.com/andreychh/tgen/model/prose"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+const (
+	replyMarkupRef          = model.Reference("replymarkup")
+	inlineKeyboardMarkupRef = model.Reference("inlinekeyboardmarkup")
+	replyKeyboardMarkupRef  = model.Reference("replykeyboardmarkup")
+	replyKeyboardRemoveRef  = model.Reference("replykeyboardremove")
+	forceReplyRef           = model.Reference("forcereply")
+)
+
+// ReplyMarkup is a [Rule] that introduces the ReplyMarkup union — the four
+// kinds of reply markup a message may carry — and redirects every field
+// typed as their union to it.
+type ReplyMarkup struct{}
+
+// Apply implements [Rule]. It fails when replymarkup already names something
+// else in spec.
+func (r ReplyMarkup) Apply(spec Specification) (Specification, error) {
+	if alreadyExists(spec, replyMarkupRef) {
+		return Specification{}, fmt.Errorf(
+			"%s already names something else in spec",
+			replyMarkupRef,
+		)
+	}
+	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing reply markup union: %w", err)
+	}
+	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing reply markup variants: %w", err)
+	}
+	fields, err := pipeline.NewMappedTable(spec.Fields, replyMarkupMapping{}).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("redirecting reply markup fields: %w", err)
+	}
+	return Specification{
+		Objects:  spec.Objects,
+		Methods:  spec.Methods,
+		Fields:   fields,
+		Unions:   unions,
+		Variants: variants,
+		Aliases:  spec.Aliases,
+		Release:  spec.Release,
+	}, nil
+}
+
+// union returns the table holding the single ReplyMarkup union definition.
+func (r ReplyMarkup) union() parsed.Unions {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
+	out.Insert(replyMarkupRef, parsed.Union{
+		Ref:  replyMarkupRef,
+		Name: "ReplyMarkup",
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"ReplyMarkup represents a reply markup attached to a message.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// variants returns the table of ReplyMarkup's four variants, each already a
+// documented object.
+func (r ReplyMarkup) variants() parsed.Variants {
+	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](4)
+	out.Insert(
+		model.VariantKey{Owner: replyMarkupRef, Ref: inlineKeyboardMarkupRef},
+		parsed.Variant{Ref: inlineKeyboardMarkupRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: replyMarkupRef, Ref: replyKeyboardMarkupRef},
+		parsed.Variant{Ref: replyKeyboardMarkupRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: replyMarkupRef, Ref: replyKeyboardRemoveRef},
+		parsed.Variant{Ref: replyKeyboardRemoveRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: replyMarkupRef, Ref: forceReplyRef},
+		parsed.Variant{Ref: forceReplyRef},
+	)
+	return out
+}
+
+// replyMarkupMapping is a [pipeline.Mapping] that redirects a field typed as
+// the four-variant reply markup union to ReplyMarkup; every other field
+// rides through unchanged.
+type replyMarkupMapping struct{}
+
+// Apply implements [pipeline.Mapping]. It never fails.
+func (replyMarkupMapping) Apply(field typed.Field) (typed.Field, error) {
+	if !field.Type.Equals(typetree.NewUnion(
+		typetree.NewNamed(inlineKeyboardMarkupRef),
+		typetree.NewNamed(replyKeyboardMarkupRef),
+		typetree.NewNamed(replyKeyboardRemoveRef),
+		typetree.NewNamed(forceReplyRef),
+	)) {
+		return field, nil
+	}
+	return typed.Field{
+		Key:         field.Key,
+		Position:    field.Position,
+		Type:        typetree.NewNamed(replyMarkupRef),
+		Optionality: field.Optionality,
+		Description: field.Description,
+	}, nil
+}

--- a/model/pipeline/modified/rich_text.go
+++ b/model/pipeline/modified/rich_text.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/prose"
+	typetree "github.com/andreychh/tgen/model/types/v2"
+)
+
+const (
+	richTextRef         = model.Reference("richtext")
+	richTextPlainRef    = model.Reference("richtextplain")
+	richTextSequenceRef = model.Reference("richtextsequence")
+)
+
+// RichText is a [Rule] that introduces RichTextPlain and RichTextSequence —
+// the two RichText variants the documentation writes as prose (a plain
+// String, an Array of RichText) rather than as list items — and adds them as
+// variants of the documented RichText union.
+type RichText struct{}
+
+// Apply implements [Rule]. It fails when richtextplain or richtextsequence
+// already names something else in spec.
+func (r RichText) Apply(spec Specification) (Specification, error) {
+	for _, ref := range []model.Reference{richTextPlainRef, richTextSequenceRef} {
+		if alreadyExists(spec, ref) {
+			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
+		}
+	}
+	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing rich text aliases: %w", err)
+	}
+	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing rich text variants: %w", err)
+	}
+	return Specification{
+		Objects:  spec.Objects,
+		Methods:  spec.Methods,
+		Fields:   spec.Fields,
+		Unions:   spec.Unions,
+		Variants: variants,
+		Aliases:  aliases,
+		Release:  spec.Release,
+	}, nil
+}
+
+// aliases returns the table of RichText's two prose-only variants: a plain
+// string, and an array of RichText itself.
+func (r RichText) aliases() Aliases {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](2)
+	out.Insert(richTextPlainRef, Alias{
+		Ref:  richTextPlainRef,
+		Name: "RichTextPlain",
+		Type: typetree.NewPrimitive(typetree.String),
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"RichTextPlain represents the plain-text variant of a RichText value.",
+			prose.StylePlain,
+		))),
+	})
+	out.Insert(richTextSequenceRef, Alias{
+		Ref:  richTextSequenceRef,
+		Name: "RichTextSequence",
+		Type: typetree.NewArray(typetree.NewNamed(richTextRef)),
+		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"RichTextSequence represents the nested-array variant of a RichText value.",
+			prose.StylePlain,
+		))),
+	})
+	return out
+}
+
+// variants returns the table of RichTextPlain and RichTextSequence as
+// variants of the documented RichText union.
+func (r RichText) variants() parsed.Variants {
+	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](2)
+	out.Insert(
+		model.VariantKey{Owner: richTextRef, Ref: richTextPlainRef},
+		parsed.Variant{Ref: richTextPlainRef},
+	)
+	out.Insert(
+		model.VariantKey{Owner: richTextRef, Ref: richTextSequenceRef},
+		parsed.Variant{Ref: richTextSequenceRef},
+	)
+	return out
+}

--- a/model/pipeline/modified/specification.go
+++ b/model/pipeline/modified/specification.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package modified applies tgen's own type corrections on top of the
+// resolved specification: it introduces union and alias definitions the
+// documentation does not name, and redirects matching field or method types
+// to them.
+package modified
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/resolved"
+	"github.com/andreychh/tgen/model/pipeline/typed"
+)
+
+// Aliases is the table of tgen-introduced aliases, keyed by reference.
+type Aliases = pipeline.Table[model.Reference, Alias]
+
+// Specification is the database after tgen's own corrections are applied on
+// top of the resolved stage: rules may introduce union or alias definitions
+// the documentation does not name, and redirect matching field or method
+// types to them.
+type Specification struct {
+	Objects  parsed.Objects
+	Methods  resolved.Methods
+	Fields   typed.Fields
+	Unions   parsed.Unions
+	Variants parsed.Variants
+	Aliases  Aliases
+	Release  parsed.Release
+}
+
+// Rule is a single tgen-introduced correction: given a specification, it
+// returns the specification with its own definition introduced and any
+// matching field or method type redirected to it.
+type Rule interface {
+	// Apply returns spec with this rule's correction applied. It fails when spec
+	// already contains a definition the rule means to introduce.
+	Apply(spec Specification) (Specification, error)
+}
+
+// Pass is the correction stage: it rewrites a resolved specification into a
+// modified one, applying tgen's own rules in order.
+type Pass struct {
+	spec resolved.Specification
+}
+
+// NewPass constructs a Pass over a resolved specification.
+func NewPass(spec resolved.Specification) Pass {
+	return Pass{spec: spec}
+}
+
+// Specification returns the modified specification, applying every rule tgen
+// introduces, in order. No rule matches a type shape another rule produces, so
+// the order is not significant; a rule added here must keep that true. It
+// fails when any rule fails.
+func (p Pass) Specification() (Specification, error) {
+	spec := Specification{
+		Objects:  p.spec.Objects,
+		Methods:  p.spec.Methods,
+		Fields:   p.spec.Fields,
+		Unions:   p.spec.Unions,
+		Variants: p.spec.Variants,
+		Aliases:  pipeline.NewMapTable[model.Reference, Alias](),
+		Release:  p.spec.Release,
+	}
+	rules := []Rule{
+		ChatID{},
+		ReplyMarkup{},
+		InputMediaGroup{},
+		InputRichMedia{},
+		InputFile{},
+		MaybeMessage{},
+		RichText{},
+	}
+	for _, rule := range rules {
+		next, err := rule.Apply(spec)
+		if err != nil {
+			return Specification{}, fmt.Errorf("applying rule: %w", err)
+		}
+		spec = next
+	}
+	return spec, nil
+}
+
+// alreadyExists reports whether ref already names an object, method, union, or
+// alias in spec. Methods count: a target renders each one as a type, so a
+// method and a union sharing a reference collide there.
+func alreadyExists(spec Specification, ref model.Reference) bool {
+	if _, ok := spec.Objects.Lookup(ref); ok {
+		return true
+	}
+	if _, ok := spec.Methods.Lookup(ref); ok {
+		return true
+	}
+	if _, ok := spec.Unions.Lookup(ref); ok {
+		return true
+	}
+	_, ok := spec.Aliases.Lookup(ref)
+	return ok
+}

--- a/model/pipeline/pipeline.go
+++ b/model/pipeline/pipeline.go
@@ -10,12 +10,12 @@ import (
 // Record represents a single row held by a [Table].
 type Record any
 
-// Table represents a set of records keyed by K, each key identifying at most
-// one record.
+// Table represents a read-only view of a set of records keyed by K, each key
+// identifying at most one record. Table exposes no mutating method: a table may
+// be shared by every stage downstream of the one that built it, so mutation
+// lives only on the concrete builder ([MapTable]) a stage constructs for
+// itself, never on a Table received from elsewhere.
 type Table[K comparable, R Record] interface {
-	// Insert adds record under key. The key must be absent; inserting a key that is
-	// already present panics.
-	Insert(key K, record R)
 	// Lookup returns the record stored under key. The boolean reports whether such
 	// a record is present; when absent, the record is the zero value.
 	Lookup(key K) (R, bool)


### PR DESCRIPTION
This PR adds a `modified` pass to `model/pipeline` that applies tgen's own type corrections over the tables, introducing the unions and aliases the documentation never names and redirecting every field or method type that matches one.

A rule takes and returns a whole `Specification` rather than a single field, the way an `overlays.Overlay` did: a correction has to introduce its own union, variants, and aliases alongside the redirect, and `MaybeMessage` rewrites a method result rather than a field type.

Closes #233