### PR TITLE
Move the `classified` pass to the front of the pipeline

### DIFF
--- a/model/pipeline/classified/discriminator.go
+++ b/model/pipeline/classified/discriminator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
 	"github.com/andreychh/tgen/model/pipeline/classified/discriminator"
-	"github.com/andreychh/tgen/model/pipeline/typed"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
 )
 
 // Discriminator is the fixed value a field's description decodes for the
@@ -22,11 +22,11 @@ type Discriminator struct {
 // position zero for the fixed discriminator value its description may carry,
 // keyed by the reference of the field's owner.
 type DiscriminatorTable struct {
-	fields typed.Fields
+	fields parsed.Fields
 }
 
 // NewDiscriminatorTable constructs a DiscriminatorTable over fields.
-func NewDiscriminatorTable(fields typed.Fields) DiscriminatorTable {
+func NewDiscriminatorTable(fields parsed.Fields) DiscriminatorTable {
 	return DiscriminatorTable{fields: fields}
 }
 

--- a/model/pipeline/classified/field.go
+++ b/model/pipeline/classified/field.go
@@ -5,13 +5,13 @@ package classified
 
 import (
 	"github.com/andreychh/tgen/model"
-	"github.com/andreychh/tgen/model/pipeline/typed"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
 )
 
-// Field is a classified field, an alias of [typed.Field]: the classified
+// Field is a classified field, an alias of [parsed.Field]: the classified
 // stage changes which fields belong to Fields, not the shape of any single
 // field.
-type Field = typed.Field
+type Field = parsed.Field
 
 // FieldFilter is a [pipeline.Filter] that excludes a field already extracted
 // into discriminators.

--- a/model/pipeline/classified/specification.go
+++ b/model/pipeline/classified/specification.go
@@ -9,7 +9,6 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
-	"github.com/andreychh/tgen/model/pipeline/resolved"
 )
 
 // Fields is the table of classified fields, keyed by owner reference and
@@ -23,28 +22,29 @@ type Discriminators = pipeline.Table[model.Reference, Discriminator]
 
 // Specification is the database after every field's description is decoded
 // for the fixed discriminator value it may carry: a field that decodes one
-// moves from Fields into Discriminators. The object, method, union, and
-// variant tables and the release ride through from the resolved stage
+// moves from Fields into Discriminators. The object, method, parameter, union,
+// and variant tables and the release ride through from the parsed stage
 // unchanged.
 type Specification struct {
 	Objects        parsed.Objects
-	Methods        resolved.Methods
+	Methods        parsed.Methods
 	Fields         Fields
+	Params         parsed.Params
 	Discriminators Discriminators
 	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Release        parsed.Release
 }
 
-// Pass is the classification stage: it rewrites a resolved specification into
-// a classified one, moving each field whose description decodes a fixed
+// Pass is the classification stage: it rewrites a parsed specification into a
+// classified one, moving each field whose description decodes a fixed
 // discriminator value out of Fields and into Discriminators.
 type Pass struct {
-	spec resolved.Specification
+	spec parsed.Specification
 }
 
-// NewPass constructs a Pass over a resolved specification.
-func NewPass(spec resolved.Specification) Pass {
+// NewPass constructs a Pass over a parsed specification.
+func NewPass(spec parsed.Specification) Pass {
 	return Pass{spec: spec}
 }
 
@@ -58,6 +58,7 @@ func (p Pass) Specification() Specification {
 		Objects:        p.spec.Objects,
 		Methods:        p.spec.Methods,
 		Fields:         fields,
+		Params:         p.spec.Params,
 		Discriminators: discriminators,
 		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,

--- a/model/pipeline/modified/chat_id.go
+++ b/model/pipeline/modified/chat_id.go
@@ -50,13 +50,14 @@ func (r ChatID) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting chat id fields: %w", err)
 	}
 	return Specification{
-		Objects:  spec.Objects,
-		Methods:  spec.Methods,
-		Fields:   fields,
-		Unions:   unions,
-		Variants: variants,
-		Aliases:  aliases,
-		Release:  spec.Release,
+		Objects:        spec.Objects,
+		Methods:        spec.Methods,
+		Fields:         fields,
+		Discriminators: spec.Discriminators,
+		Unions:         unions,
+		Variants:       variants,
+		Aliases:        aliases,
+		Release:        spec.Release,
 	}, nil
 }
 

--- a/model/pipeline/modified/input_file.go
+++ b/model/pipeline/modified/input_file.go
@@ -51,13 +51,14 @@ func (r InputFile) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting input file fields: %w", err)
 	}
 	return Specification{
-		Objects:  objects,
-		Methods:  spec.Methods,
-		Fields:   fields,
-		Unions:   unions,
-		Variants: variants,
-		Aliases:  aliases,
-		Release:  spec.Release,
+		Objects:        objects,
+		Methods:        spec.Methods,
+		Fields:         fields,
+		Discriminators: spec.Discriminators,
+		Unions:         unions,
+		Variants:       variants,
+		Aliases:        aliases,
+		Release:        spec.Release,
 	}, nil
 }
 

--- a/model/pipeline/modified/input_media_group.go
+++ b/model/pipeline/modified/input_media_group.go
@@ -47,13 +47,14 @@ func (r InputMediaGroup) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting input media group fields: %w", err)
 	}
 	return Specification{
-		Objects:  spec.Objects,
-		Methods:  spec.Methods,
-		Fields:   fields,
-		Unions:   unions,
-		Variants: variants,
-		Aliases:  spec.Aliases,
-		Release:  spec.Release,
+		Objects:        spec.Objects,
+		Methods:        spec.Methods,
+		Fields:         fields,
+		Discriminators: spec.Discriminators,
+		Unions:         unions,
+		Variants:       variants,
+		Aliases:        spec.Aliases,
+		Release:        spec.Release,
 	}, nil
 }
 

--- a/model/pipeline/modified/input_rich_media.go
+++ b/model/pipeline/modified/input_rich_media.go
@@ -50,13 +50,14 @@ func (r InputRichMedia) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting input rich media fields: %w", err)
 	}
 	return Specification{
-		Objects:  spec.Objects,
-		Methods:  spec.Methods,
-		Fields:   fields,
-		Unions:   unions,
-		Variants: variants,
-		Aliases:  spec.Aliases,
-		Release:  spec.Release,
+		Objects:        spec.Objects,
+		Methods:        spec.Methods,
+		Fields:         fields,
+		Discriminators: spec.Discriminators,
+		Unions:         unions,
+		Variants:       variants,
+		Aliases:        spec.Aliases,
+		Release:        spec.Release,
 	}, nil
 }
 

--- a/model/pipeline/modified/maybe_message.go
+++ b/model/pipeline/modified/maybe_message.go
@@ -51,13 +51,14 @@ func (r MaybeMessage) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting maybe message methods: %w", err)
 	}
 	return Specification{
-		Objects:  spec.Objects,
-		Methods:  methods,
-		Fields:   spec.Fields,
-		Unions:   unions,
-		Variants: variants,
-		Aliases:  aliases,
-		Release:  spec.Release,
+		Objects:        spec.Objects,
+		Methods:        methods,
+		Fields:         spec.Fields,
+		Discriminators: spec.Discriminators,
+		Unions:         unions,
+		Variants:       variants,
+		Aliases:        aliases,
+		Release:        spec.Release,
 	}, nil
 }
 

--- a/model/pipeline/modified/reply_markup.go
+++ b/model/pipeline/modified/reply_markup.go
@@ -49,13 +49,14 @@ func (r ReplyMarkup) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting reply markup fields: %w", err)
 	}
 	return Specification{
-		Objects:  spec.Objects,
-		Methods:  spec.Methods,
-		Fields:   fields,
-		Unions:   unions,
-		Variants: variants,
-		Aliases:  spec.Aliases,
-		Release:  spec.Release,
+		Objects:        spec.Objects,
+		Methods:        spec.Methods,
+		Fields:         fields,
+		Discriminators: spec.Discriminators,
+		Unions:         unions,
+		Variants:       variants,
+		Aliases:        spec.Aliases,
+		Release:        spec.Release,
 	}, nil
 }
 

--- a/model/pipeline/modified/rich_text.go
+++ b/model/pipeline/modified/rich_text.go
@@ -42,13 +42,14 @@ func (r RichText) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("introducing rich text variants: %w", err)
 	}
 	return Specification{
-		Objects:  spec.Objects,
-		Methods:  spec.Methods,
-		Fields:   spec.Fields,
-		Unions:   spec.Unions,
-		Variants: variants,
-		Aliases:  aliases,
-		Release:  spec.Release,
+		Objects:        spec.Objects,
+		Methods:        spec.Methods,
+		Fields:         spec.Fields,
+		Discriminators: spec.Discriminators,
+		Unions:         spec.Unions,
+		Variants:       variants,
+		Aliases:        aliases,
+		Release:        spec.Release,
 	}, nil
 }
 

--- a/model/pipeline/modified/specification.go
+++ b/model/pipeline/modified/specification.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/classified"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 	"github.com/andreychh/tgen/model/pipeline/resolved"
 	"github.com/andreychh/tgen/model/pipeline/typed"
@@ -25,13 +26,14 @@ type Aliases = pipeline.Table[model.Reference, Alias]
 // the documentation does not name, and redirect matching field or method
 // types to them.
 type Specification struct {
-	Objects  parsed.Objects
-	Methods  resolved.Methods
-	Fields   typed.Fields
-	Unions   parsed.Unions
-	Variants parsed.Variants
-	Aliases  Aliases
-	Release  parsed.Release
+	Objects        parsed.Objects
+	Methods        resolved.Methods
+	Fields         typed.Fields
+	Discriminators classified.Discriminators
+	Unions         parsed.Unions
+	Variants       parsed.Variants
+	Aliases        Aliases
+	Release        parsed.Release
 }
 
 // Rule is a single tgen-introduced correction: given a specification, it
@@ -60,13 +62,14 @@ func NewPass(spec resolved.Specification) Pass {
 // fails when any rule fails.
 func (p Pass) Specification() (Specification, error) {
 	spec := Specification{
-		Objects:  p.spec.Objects,
-		Methods:  p.spec.Methods,
-		Fields:   p.spec.Fields,
-		Unions:   p.spec.Unions,
-		Variants: p.spec.Variants,
-		Aliases:  pipeline.NewMapTable[model.Reference, Alias](),
-		Release:  p.spec.Release,
+		Objects:        p.spec.Objects,
+		Methods:        p.spec.Methods,
+		Fields:         p.spec.Fields,
+		Discriminators: p.spec.Discriminators,
+		Unions:         p.spec.Unions,
+		Variants:       p.spec.Variants,
+		Aliases:        pipeline.NewMapTable[model.Reference, Alias](),
+		Release:        p.spec.Release,
 	}
 	rules := []Rule{
 		ChatID{},

--- a/model/pipeline/resolved/specification.go
+++ b/model/pipeline/resolved/specification.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/classified"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 	"github.com/andreychh/tgen/model/pipeline/typed"
 )
@@ -18,16 +19,17 @@ import (
 type Methods = pipeline.Table[model.Reference, Method]
 
 // Specification is the database after every method's return type is decoded
-// from its description prose into a [result.Result]. The object, field, union,
-// and variant tables and the release ride through from the typed stage
-// unchanged.
+// from its description prose into a [result.Result]. The object, field,
+// discriminator, union, and variant tables and the release ride through from
+// the typed stage unchanged.
 type Specification struct {
-	Objects  parsed.Objects
-	Methods  Methods
-	Fields   typed.Fields
-	Unions   parsed.Unions
-	Variants parsed.Variants
-	Release  parsed.Release
+	Objects        parsed.Objects
+	Methods        Methods
+	Fields         typed.Fields
+	Discriminators classified.Discriminators
+	Unions         parsed.Unions
+	Variants       parsed.Variants
+	Release        parsed.Release
 }
 
 // Pass is the resolution stage: it rewrites a typed specification into a
@@ -50,11 +52,12 @@ func (p Pass) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("resolving methods: %w", err)
 	}
 	return Specification{
-		Objects:  p.spec.Objects,
-		Methods:  methods,
-		Fields:   p.spec.Fields,
-		Unions:   p.spec.Unions,
-		Variants: p.spec.Variants,
-		Release:  p.spec.Release,
+		Objects:        p.spec.Objects,
+		Methods:        methods,
+		Fields:         p.spec.Fields,
+		Discriminators: p.spec.Discriminators,
+		Unions:         p.spec.Unions,
+		Variants:       p.spec.Variants,
+		Release:        p.spec.Release,
 	}, nil
 }

--- a/model/pipeline/typed/specification.go
+++ b/model/pipeline/typed/specification.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/classified"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 	"github.com/andreychh/tgen/model/pipeline/unified"
 )
@@ -18,15 +19,16 @@ import (
 type Fields = pipeline.Table[model.FieldKey, Field]
 
 // Specification is the database after every field's type prose is resolved into
-// a type expression. The object, method, union, and variant tables and the
-// release ride through from the unified stage unchanged.
+// a type expression. The object, method, discriminator, union, and variant
+// tables and the release ride through from the unified stage unchanged.
 type Specification struct {
-	Objects  parsed.Objects
-	Methods  parsed.Methods
-	Fields   Fields
-	Unions   parsed.Unions
-	Variants parsed.Variants
-	Release  parsed.Release
+	Objects        parsed.Objects
+	Methods        parsed.Methods
+	Fields         Fields
+	Discriminators classified.Discriminators
+	Unions         parsed.Unions
+	Variants       parsed.Variants
+	Release        parsed.Release
 }
 
 // Pass is the typing stage: it rewrites a unified specification into a typed
@@ -49,11 +51,12 @@ func (p Pass) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("typing fields: %w", err)
 	}
 	return Specification{
-		Objects:  p.spec.Objects,
-		Methods:  p.spec.Methods,
-		Fields:   fields,
-		Unions:   p.spec.Unions,
-		Variants: p.spec.Variants,
-		Release:  p.spec.Release,
+		Objects:        p.spec.Objects,
+		Methods:        p.spec.Methods,
+		Fields:         fields,
+		Discriminators: p.spec.Discriminators,
+		Unions:         p.spec.Unions,
+		Variants:       p.spec.Variants,
+		Release:        p.spec.Release,
 	}, nil
 }

--- a/model/pipeline/unified/specification.go
+++ b/model/pipeline/unified/specification.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/classified"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 )
 
@@ -18,25 +19,27 @@ import (
 type Fields = pipeline.Table[model.FieldKey, Field]
 
 // Specification is the database after object fields and method parameters are
-// merged into a single table of fields. The object, method, union, and variant
-// tables and the release ride through from the parsed stage unchanged.
+// merged into a single table of fields. The object, method, discriminator,
+// union, and variant tables and the release ride through from the classified
+// stage unchanged.
 type Specification struct {
-	Objects  parsed.Objects
-	Methods  parsed.Methods
-	Fields   Fields
-	Unions   parsed.Unions
-	Variants parsed.Variants
-	Release  parsed.Release
+	Objects        parsed.Objects
+	Methods        parsed.Methods
+	Fields         Fields
+	Discriminators classified.Discriminators
+	Unions         parsed.Unions
+	Variants       parsed.Variants
+	Release        parsed.Release
 }
 
-// Pass is the unification stage: it rewrites a parsed specification into a
+// Pass is the unification stage: it rewrites a classified specification into a
 // unified one, merging object fields and method parameters into a single table.
 type Pass struct {
-	spec parsed.Specification
+	spec classified.Specification
 }
 
-// NewPass constructs a Pass over a parsed specification.
-func NewPass(spec parsed.Specification) Pass {
+// NewPass constructs a Pass over a classified specification.
+func NewPass(spec classified.Specification) Pass {
 	return Pass{spec: spec}
 }
 
@@ -57,11 +60,12 @@ func (p Pass) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("merging fields and parameters: %w", err)
 	}
 	return Specification{
-		Objects:  p.spec.Objects,
-		Methods:  p.spec.Methods,
-		Fields:   merged,
-		Unions:   p.spec.Unions,
-		Variants: p.spec.Variants,
-		Release:  p.spec.Release,
+		Objects:        p.spec.Objects,
+		Methods:        p.spec.Methods,
+		Fields:         merged,
+		Discriminators: p.spec.Discriminators,
+		Unions:         p.spec.Unions,
+		Variants:       p.spec.Variants,
+		Release:        p.spec.Release,
 	}, nil
 }


### PR DESCRIPTION
This PR moves the `classified` pass ahead of `unified` so that it consumes a `parsed.Specification`, joining the six passes into a single chain and carrying `Discriminators` through every stage that follows.

Nothing forced the pass to sit after `resolved` — it reads only a field's key, position, and description, all of which `parsed` already decodes — and running it before object fields and method parameters merge also matches the domain, since only an object field can carry a discriminator.

Closes #237