### PR TITLE
Carry the method description through the `resolved` pass

### DIFF
--- a/model/pipeline/modified/maybe_message.go
+++ b/model/pipeline/modified/maybe_message.go
@@ -127,8 +127,9 @@ func (maybeMessageMapping) Apply(method resolved.Method) (resolved.Method, error
 		return method, nil
 	}
 	return resolved.Method{
-		Ref:    method.Ref,
-		Name:   method.Name,
-		Result: result.NewValue(typetree.NewNamed(maybeMessageRef)),
+		Ref:         method.Ref,
+		Name:        method.Name,
+		Description: method.Description,
+		Result:      result.NewValue(typetree.NewNamed(maybeMessageRef)),
 	}, nil
 }

--- a/model/pipeline/resolved/method.go
+++ b/model/pipeline/resolved/method.go
@@ -9,16 +9,18 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 	"github.com/andreychh/tgen/model/pipeline/resolved/types"
+	"github.com/andreychh/tgen/model/prose"
 	"github.com/andreychh/tgen/model/result"
 	typetree "github.com/andreychh/tgen/model/types/v2"
 )
 
 // Method is the decoded record of a documentation method after its return type
-// is resolved: its reference, name, and what it returns.
+// is resolved: its reference, name, description, and what it returns.
 type Method struct {
-	Ref    model.Reference
-	Name   model.Name
-	Result result.Result
+	Ref         model.Reference
+	Name        model.Name
+	Description prose.Passage
+	Result      result.Result
 }
 
 // MethodMapping maps a parsed method into a resolved method by decoding its
@@ -38,9 +40,10 @@ func (m MethodMapping) Apply(method parsed.Method) (Method, error) {
 		return Method{}, fmt.Errorf("decoding return type: %w", err)
 	}
 	return Method{
-		Ref:    method.Ref,
-		Name:   method.Name,
-		Result: m.classify(expr),
+		Ref:         method.Ref,
+		Name:        method.Name,
+		Description: method.Description,
+		Result:      m.classify(expr),
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds a `Description` field to `resolved.Method` and fills it from the parsed method, so that a method's prose survives to the end of the pipeline.

The description travels verbatim, with the return clause the `Result` was decoded from still inside it, since that is what the generated code prints today.

Closes #238