### PR TITLE
Collapse the per-kind definition tables into `Definitions`

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -11,12 +11,28 @@ type Name string
 
 type Reference string
 
+// DefinitionKind classifies what a reference names, telling a target which
+// shape to render it as. It is not the kind of a documentation heading: a
+// heading may announce nothing recognizable, which no definition is, and no
+// heading announces an alias, which tgen introduces on its own.
+type DefinitionKind string
+
+const (
+	DefinitionKindObject DefinitionKind = "object"
+	DefinitionKindMethod DefinitionKind = "method"
+	DefinitionKindUnion  DefinitionKind = "union"
+	DefinitionKindAlias  DefinitionKind = "alias"
+)
+
 type Optionality bool
 
 type Key string
 
-// Position identifies a field's place among the other fields owned by the
-// same reference: zero-based, unique and gapless within that owner's fields.
+// Position is where a record's source put it: a field among the rows of its
+// owner's table, a definition among the headings of the page. It is assigned
+// once, when the record is read, and never recomputed, so a table that drops
+// records keeps the gaps their positions leave behind. Which positions a
+// given table admits is stated by that table.
 type Position int
 
 type DiscriminatorValue string

--- a/model/pipeline/classified/specification.go
+++ b/model/pipeline/classified/specification.go
@@ -13,7 +13,9 @@ import (
 
 // Fields is the table of classified fields, keyed by owner reference and
 // field key: every field whose description decodes a fixed discriminator
-// value is excluded.
+// value is excluded. Positions carry over from [parsed.Fields] unchanged, so
+// an owner that lost a field has no field at position zero and its remaining
+// fields are gapless only among themselves.
 type Fields = pipeline.Table[model.FieldKey, Field]
 
 // Discriminators is the table of fixed discriminator values decoded out of
@@ -22,16 +24,13 @@ type Discriminators = pipeline.Table[model.Reference, Discriminator]
 
 // Specification is the database after every field's description is decoded
 // for the fixed discriminator value it may carry: a field that decodes one
-// moves from Fields into Discriminators. The object, method, parameter, union,
-// and variant tables and the release ride through from the parsed stage
-// unchanged.
+// moves from Fields into Discriminators. The definition, parameter, and
+// variant tables and the release ride through from the parsed stage unchanged.
 type Specification struct {
-	Objects        parsed.Objects
-	Methods        parsed.Methods
+	Definitions    parsed.Definitions
 	Fields         Fields
 	Params         parsed.Params
 	Discriminators Discriminators
-	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Release        parsed.Release
 }
@@ -55,12 +54,10 @@ func (p Pass) Specification() Specification {
 	discriminators := NewDiscriminatorTable(p.spec.Fields).Apply()
 	fields := pipeline.NewFilteredTable(p.spec.Fields, NewFieldFilter(discriminators)).Apply()
 	return Specification{
-		Objects:        p.spec.Objects,
-		Methods:        p.spec.Methods,
+		Definitions:    p.spec.Definitions,
 		Fields:         fields,
 		Params:         p.spec.Params,
 		Discriminators: discriminators,
-		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,
 		Release:        p.spec.Release,
 	}

--- a/model/pipeline/corrected/alias.go
+++ b/model/pipeline/corrected/alias.go
@@ -5,16 +5,13 @@ package corrected
 
 import (
 	"github.com/andreychh/tgen/model"
-	"github.com/andreychh/tgen/model/prose"
 	"github.com/andreychh/tgen/model/typeexpr"
 )
 
-// Alias is a name tgen introduces for a type expression the documentation
-// leaves unnamed. Its description is tgen's own, since the documentation has
-// none for a type it never names.
+// Alias is the type a name tgen introduces stands for. What the alias is
+// called and how it is described lives in the definitions table under the
+// alias kind, alongside everything else the pipeline names.
 type Alias struct {
-	Ref         model.Reference
-	Name        model.Name
-	Type        typeexpr.Expression
-	Description prose.Passage
+	Ref  model.Reference
+	Type typeexpr.Expression
 }

--- a/model/pipeline/corrected/chat_id.go
+++ b/model/pipeline/corrected/chat_id.go
@@ -29,20 +29,15 @@ type ChatID struct{}
 // Apply implements [Rule]. It fails when chatid, id, or username already
 // names something else in spec.
 func (r ChatID) Apply(spec Specification) (Specification, error) {
-	for _, ref := range []model.Reference{chatIDRef, idRef, usernameRef} {
-		if alreadyExists(spec, ref) {
-			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
-		}
+	definitions, err := r.definitions(spec.Definitions)
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing chat id definitions: %w", err)
 	}
 	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing chat id aliases: %w", err)
 	}
-	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
-	if err != nil {
-		return Specification{}, fmt.Errorf("introducing chat id union: %w", err)
-	}
-	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	variants, err := r.variants(spec.Variants)
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing chat id variants: %w", err)
 	}
@@ -51,68 +46,80 @@ func (r ChatID) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting chat id fields: %w", err)
 	}
 	return Specification{
-		Objects:        spec.Objects,
+		Definitions:    definitions,
 		Methods:        spec.Methods,
 		Fields:         fields,
 		Discriminators: spec.Discriminators,
-		Unions:         unions,
 		Variants:       variants,
 		Aliases:        aliases,
 		Release:        spec.Release,
 	}, nil
 }
 
-// aliases returns the table of primitive aliases ChatID's variants need: a
-// numeric id and a username, neither of which the documentation names.
-func (r ChatID) aliases() Aliases {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](2)
-	out.Insert(idRef, Alias{
-		Ref:  idRef,
-		Name: "Id",
-		Type: typeexpr.NewPrimitive(primitive.Integer),
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
-			"ID represents a numeric Telegram chat or user identifier.",
-			prose.StylePlain,
-		))),
-	})
-	out.Insert(usernameRef, Alias{
-		Ref:  usernameRef,
-		Name: "Username",
-		Type: typeexpr.NewPrimitive(primitive.String),
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
-			"Username represents a Telegram username.",
-			prose.StylePlain,
-		))),
-	})
-	return out
-}
-
-// union returns the table holding the single ChatID union definition.
-func (r ChatID) union() parsed.Unions {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
-	out.Insert(chatIDRef, parsed.Union{
-		Ref:  chatIDRef,
-		Name: "ChatId",
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+// definitions returns base holding what ChatID names too: the union itself and
+// the two primitive aliases its variants stand for, neither of which the
+// documentation names. It fails when any of the three references is taken.
+func (r ChatID) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+	out := NewDefinitionTable(base)
+	err := out.Insert(
+		chatIDRef,
+		"ChatId",
+		model.DefinitionKindUnion,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
 			"ChatId represents a chat identifier, either a numeric ID or a username.",
 			prose.StylePlain,
 		))),
-	})
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the chat id union: %w", err)
+	}
+	err = out.Insert(
+		idRef,
+		"Id",
+		model.DefinitionKindAlias,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"ID represents a numeric Telegram chat or user identifier.",
+			prose.StylePlain,
+		))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the id alias: %w", err)
+	}
+	err = out.Insert(
+		usernameRef,
+		"Username",
+		model.DefinitionKindAlias,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"Username represents a Telegram username.",
+			prose.StylePlain,
+		))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the username alias: %w", err)
+	}
+	return out, nil
+}
+
+// aliases returns the type each alias ChatID introduces stands for.
+func (r ChatID) aliases() Aliases {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](2)
+	out.Insert(idRef, Alias{Ref: idRef, Type: typeexpr.NewPrimitive(primitive.Integer)})
+	out.Insert(usernameRef, Alias{Ref: usernameRef, Type: typeexpr.NewPrimitive(primitive.String)})
 	return out
 }
 
-// variants returns the table of ChatID's two variants, id and username.
-func (r ChatID) variants() parsed.Variants {
-	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](2)
-	out.Insert(
-		model.VariantKey{Owner: chatIDRef, Ref: idRef},
-		parsed.Variant{Ref: idRef},
+// variants returns base listing ChatID's two variants, id and username. It
+// fails when the union already lists either.
+func (r ChatID) variants(base parsed.Variants) (parsed.Variants, error) {
+	out := NewVariantTable(base, chatIDRef)
+	err := out.Insert(
+		idRef,
+		usernameRef,
 	)
-	out.Insert(
-		model.VariantKey{Owner: chatIDRef, Ref: usernameRef},
-		parsed.Variant{Ref: usernameRef},
-	)
-	return out
+	if err != nil {
+		return nil, fmt.Errorf("listing chat id variants: %w", err)
+	}
+	return out, nil
 }
 
 // chatIDMapping is a [pipeline.Mapping] that redirects a field typed as

--- a/model/pipeline/corrected/definition_table.go
+++ b/model/pipeline/corrected/definition_table.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package corrected
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// DefinitionTable is the definitions table a rule writes into: it places every
+// definition inserted after all the definitions it already holds, so a rule
+// states what it introduces and in which order, never a position. Its zero
+// value is not usable; construct one with [NewDefinitionTable].
+type DefinitionTable struct {
+	base  parsed.Definitions
+	added pipeline.MapTable[model.Reference, parsed.Definition]
+}
+
+// NewDefinitionTable constructs a DefinitionTable over the definitions base
+// already holds.
+func NewDefinitionTable(base parsed.Definitions) DefinitionTable {
+	return DefinitionTable{
+		base:  base,
+		added: pipeline.NewMapTable[model.Reference, parsed.Definition](),
+	}
+}
+
+// Insert admits a definition tgen introduces, at the place after every
+// definition the table already holds. It fails when ref already names a
+// definition, since a reference names at most one whatever its kind.
+func (t DefinitionTable) Insert(
+	ref model.Reference,
+	name model.Name,
+	kind model.DefinitionKind,
+	description prose.Passage,
+) error {
+	if _, exists := t.Lookup(ref); exists {
+		return fmt.Errorf("%s already names a definition", ref)
+	}
+	t.added.Insert(ref, parsed.Definition{
+		Ref:         ref,
+		Name:        name,
+		Kind:        kind,
+		Position:    t.place(),
+		Description: description,
+	})
+	return nil
+}
+
+func (t DefinitionTable) Lookup(ref model.Reference) (parsed.Definition, bool) {
+	if definition, exists := t.added.Lookup(ref); exists {
+		return definition, true
+	}
+	return t.base.Lookup(ref)
+}
+
+func (t DefinitionTable) Count() int {
+	return t.base.Count() + t.added.Count()
+}
+
+func (t DefinitionTable) All() iter.Seq2[model.Reference, parsed.Definition] {
+	return func(yield func(model.Reference, parsed.Definition) bool) {
+		for ref, definition := range t.base.All() {
+			if !yield(ref, definition) {
+				return
+			}
+		}
+		for ref, definition := range t.added.All() {
+			if !yield(ref, definition) {
+				return
+			}
+		}
+	}
+}
+
+// place returns the position the next definition inserted takes: the one after
+// every definition the table holds.
+func (t DefinitionTable) place() model.Position {
+	next := model.Position(0)
+	for _, definition := range t.All() {
+		next = max(next, definition.Position+1)
+	}
+	return next
+}

--- a/model/pipeline/corrected/input_file.go
+++ b/model/pipeline/corrected/input_file.go
@@ -26,24 +26,19 @@ const (
 // InputFile object, and redirects every field that could carry one to it.
 type InputFile struct{}
 
-// Apply implements [Rule]. It fails when fileid or upload already names
-// something else in spec.
+// Apply implements [Rule]. It fails when fileid already names something else
+// in spec.
 func (r InputFile) Apply(spec Specification) (Specification, error) {
-	for _, ref := range []model.Reference{fileIDRef, uploadRef} {
-		if alreadyExists(spec, ref) {
-			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
-		}
+	documented := pipeline.NewFilteredTable(spec.Definitions, inputFileFilter{}).Apply()
+	definitions, err := r.definitions(documented)
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing input file definitions: %w", err)
 	}
-	objects := pipeline.NewFilteredTable(spec.Objects, inputFileFilter{}).Apply()
 	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing input file aliases: %w", err)
 	}
-	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
-	if err != nil {
-		return Specification{}, fmt.Errorf("introducing input file union: %w", err)
-	}
-	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	variants, err := r.variants(spec.Variants)
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing input file variants: %w", err)
 	}
@@ -52,68 +47,78 @@ func (r InputFile) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting input file fields: %w", err)
 	}
 	return Specification{
-		Objects:        objects,
+		Definitions:    definitions,
 		Methods:        spec.Methods,
 		Fields:         fields,
 		Discriminators: spec.Discriminators,
-		Unions:         unions,
 		Variants:       variants,
 		Aliases:        aliases,
 		Release:        spec.Release,
 	}, nil
 }
 
-// aliases returns the table of primitive aliases InputFile's variants need:
-// a file id, which the documentation writes as a plain String field, not a
-// named type.
-func (r InputFile) aliases() Aliases {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](1)
-	out.Insert(fileIDRef, Alias{
-		Ref:  fileIDRef,
-		Name: "FileId",
-		Type: typeexpr.NewPrimitive(primitive.String),
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
-			"FileID represents a Telegram file identifier.",
-			prose.StylePlain,
-		))),
-	})
-	return out
-}
-
-// union returns the table holding the single InputFile union definition.
-func (r InputFile) union() parsed.Unions {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
-	out.Insert(inputFileRef, parsed.Union{
-		Ref:  inputFileRef,
-		Name: "InputFile",
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+// definitions returns base holding what InputFile names too: the union itself,
+// taking the place of the documented object base no longer holds, and the file
+// id alias its variant stands for. It fails when either reference is taken.
+func (r InputFile) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+	out := NewDefinitionTable(base)
+	err := out.Insert(
+		inputFileRef,
+		"InputFile",
+		model.DefinitionKindUnion,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
 			"InputFile represents a file to send, either by file ID or by uploading.",
 			prose.StylePlain,
 		))),
-	})
-	return out
-}
-
-// variants returns the table of InputFile's variants. It carries only
-// FileId: the upload variant holds a Go io.Reader with no shape shared
-// across targets, so it still needs its own design before it can join this
-// table.
-func (r InputFile) variants() parsed.Variants {
-	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](1)
-	out.Insert(
-		model.VariantKey{Owner: inputFileRef, Ref: fileIDRef},
-		parsed.Variant{Ref: fileIDRef},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the input file union: %w", err)
+	}
+	err = out.Insert(
+		fileIDRef,
+		"FileId",
+		model.DefinitionKindAlias,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"FileID represents a Telegram file identifier.",
+			prose.StylePlain,
+		))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the file id alias: %w", err)
+	}
+	return out, nil
+}
+
+// aliases returns the type the file id alias stands for: the documentation
+// writes it as a plain String field, not a named type.
+func (r InputFile) aliases() Aliases {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](1)
+	out.Insert(fileIDRef, Alias{Ref: fileIDRef, Type: typeexpr.NewPrimitive(primitive.String)})
 	return out
 }
 
-// inputFileFilter is a [pipeline.Filter] that excludes the documented InputFile
-// object from Objects.
+// variants returns base listing InputFile's variants, which is FileId alone:
+// the upload variant holds a Go io.Reader with no shape shared across targets,
+// so it still needs its own design before it can join the union. It fails when
+// the union already lists FileId.
+func (r InputFile) variants(base parsed.Variants) (parsed.Variants, error) {
+	out := NewVariantTable(base, inputFileRef)
+	err := out.Insert(
+		fileIDRef,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing input file variants: %w", err)
+	}
+	return out, nil
+}
+
+// inputFileFilter is a [pipeline.Filter] that excludes the documented
+// InputFile object, whose place the InputFile union takes.
 type inputFileFilter struct{}
 
-// Apply implements [pipeline.Filter]. It reports whether object belongs in the
-// filtered result: false when ref is inputfile.
-func (inputFileFilter) Apply(ref model.Reference, object parsed.Object) bool {
+// Apply implements [pipeline.Filter]. It reports whether definition belongs in
+// the filtered result: false when ref is inputfile.
+func (inputFileFilter) Apply(ref model.Reference, definition parsed.Definition) bool {
 	return ref != inputFileRef
 }
 

--- a/model/pipeline/corrected/input_media_group.go
+++ b/model/pipeline/corrected/input_media_group.go
@@ -28,17 +28,11 @@ type InputMediaGroup struct{}
 // Apply implements [Rule]. It fails when inputmediagroup already names
 // something else in spec.
 func (r InputMediaGroup) Apply(spec Specification) (Specification, error) {
-	if alreadyExists(spec, inputMediaGroupRef) {
-		return Specification{}, fmt.Errorf(
-			"%s already names something else in spec",
-			inputMediaGroupRef,
-		)
-	}
-	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	definitions, err := r.definitions(spec.Definitions)
 	if err != nil {
-		return Specification{}, fmt.Errorf("introducing input media group union: %w", err)
+		return Specification{}, fmt.Errorf("introducing input media group definitions: %w", err)
 	}
-	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	variants, err := r.variants(spec.Variants)
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing input media group variants: %w", err)
 	}
@@ -47,57 +41,51 @@ func (r InputMediaGroup) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting input media group fields: %w", err)
 	}
 	return Specification{
-		Objects:        spec.Objects,
+		Definitions:    definitions,
 		Methods:        spec.Methods,
 		Fields:         fields,
 		Discriminators: spec.Discriminators,
-		Unions:         unions,
 		Variants:       variants,
 		Aliases:        spec.Aliases,
 		Release:        spec.Release,
 	}, nil
 }
 
-// union returns the table holding the single InputMediaGroup union
-// definition.
-func (r InputMediaGroup) union() parsed.Unions {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
-	out.Insert(inputMediaGroupRef, parsed.Union{
-		Ref:  inputMediaGroupRef,
-		Name: "InputMediaGroup",
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+// definitions returns base holding what InputMediaGroup names too: the union
+// itself. Its variants are documented objects and name themselves. It fails
+// when the reference is taken.
+func (r InputMediaGroup) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+	out := NewDefinitionTable(base)
+	err := out.Insert(
+		inputMediaGroupRef,
+		"InputMediaGroup",
+		model.DefinitionKindUnion,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
 			"InputMediaGroup represents a media element in a media group.",
 			prose.StylePlain,
 		))),
-	})
-	return out
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the input media group union: %w", err)
+	}
+	return out, nil
 }
 
-// variants returns the table of InputMediaGroup's five variants, each
-// already a documented object.
-func (r InputMediaGroup) variants() parsed.Variants {
-	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](5)
-	out.Insert(
-		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaAudioRef},
-		parsed.Variant{Ref: inputMediaAudioRef},
+// variants returns base listing InputMediaGroup's five variants, each already
+// a documented object. It fails when the union already lists one of them.
+func (r InputMediaGroup) variants(base parsed.Variants) (parsed.Variants, error) {
+	out := NewVariantTable(base, inputMediaGroupRef)
+	err := out.Insert(
+		inputMediaAudioRef,
+		inputMediaDocumentRef,
+		inputMediaLivePhotoRef,
+		inputMediaPhotoRef,
+		inputMediaVideoRef,
 	)
-	out.Insert(
-		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaDocumentRef},
-		parsed.Variant{Ref: inputMediaDocumentRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaLivePhotoRef},
-		parsed.Variant{Ref: inputMediaLivePhotoRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaPhotoRef},
-		parsed.Variant{Ref: inputMediaPhotoRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: inputMediaGroupRef, Ref: inputMediaVideoRef},
-		parsed.Variant{Ref: inputMediaVideoRef},
-	)
-	return out
+	if err != nil {
+		return nil, fmt.Errorf("listing input media group variants: %w", err)
+	}
+	return out, nil
 }
 
 // inputMediaGroupMapping is a [pipeline.Mapping] that redirects a field

--- a/model/pipeline/corrected/input_rich_media.go
+++ b/model/pipeline/corrected/input_rich_media.go
@@ -31,17 +31,11 @@ type InputRichMedia struct{}
 // Apply implements [Rule]. It fails when inputrichmedia already names
 // something else in spec.
 func (r InputRichMedia) Apply(spec Specification) (Specification, error) {
-	if alreadyExists(spec, inputRichMediaRef) {
-		return Specification{}, fmt.Errorf(
-			"%s already names something else in spec",
-			inputRichMediaRef,
-		)
-	}
-	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	definitions, err := r.definitions(spec.Definitions)
 	if err != nil {
-		return Specification{}, fmt.Errorf("introducing input rich media union: %w", err)
+		return Specification{}, fmt.Errorf("introducing input rich media definitions: %w", err)
 	}
-	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	variants, err := r.variants(spec.Variants)
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing input rich media variants: %w", err)
 	}
@@ -50,57 +44,51 @@ func (r InputRichMedia) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting input rich media fields: %w", err)
 	}
 	return Specification{
-		Objects:        spec.Objects,
+		Definitions:    definitions,
 		Methods:        spec.Methods,
 		Fields:         fields,
 		Discriminators: spec.Discriminators,
-		Unions:         unions,
 		Variants:       variants,
 		Aliases:        spec.Aliases,
 		Release:        spec.Release,
 	}, nil
 }
 
-// union returns the table holding the single InputRichMedia union
-// definition.
-func (r InputRichMedia) union() parsed.Unions {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
-	out.Insert(inputRichMediaRef, parsed.Union{
-		Ref:  inputRichMediaRef,
-		Name: "InputRichMedia",
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+// definitions returns base holding what InputRichMedia names too: the union
+// itself. Its variants are documented objects and name themselves. It fails
+// when the reference is taken.
+func (r InputRichMedia) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+	out := NewDefinitionTable(base)
+	err := out.Insert(
+		inputRichMediaRef,
+		"InputRichMedia",
+		model.DefinitionKindUnion,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
 			"InputRichMedia represents a media element embedded in a rich message.",
 			prose.StylePlain,
 		))),
-	})
-	return out
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the input rich media union: %w", err)
+	}
+	return out, nil
 }
 
-// variants returns the table of InputRichMedia's five variants, each
-// already a documented object.
-func (r InputRichMedia) variants() parsed.Variants {
-	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](5)
-	out.Insert(
-		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaAnimationRef},
-		parsed.Variant{Ref: inputMediaAnimationRef},
+// variants returns base listing InputRichMedia's five variants, each already
+// a documented object. It fails when the union already lists one of them.
+func (r InputRichMedia) variants(base parsed.Variants) (parsed.Variants, error) {
+	out := NewVariantTable(base, inputRichMediaRef)
+	err := out.Insert(
+		inputMediaAnimationRef,
+		inputMediaAudioRef,
+		inputMediaPhotoRef,
+		inputMediaVideoRef,
+		inputMediaVoiceNoteRef,
 	)
-	out.Insert(
-		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaAudioRef},
-		parsed.Variant{Ref: inputMediaAudioRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaPhotoRef},
-		parsed.Variant{Ref: inputMediaPhotoRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaVideoRef},
-		parsed.Variant{Ref: inputMediaVideoRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: inputRichMediaRef, Ref: inputMediaVoiceNoteRef},
-		parsed.Variant{Ref: inputMediaVoiceNoteRef},
-	)
-	return out
+	if err != nil {
+		return nil, fmt.Errorf("listing input rich media variants: %w", err)
+	}
+	return out, nil
 }
 
 // inputRichMediaMapping is a [pipeline.Mapping] that redirects a field

--- a/model/pipeline/corrected/maybe_message.go
+++ b/model/pipeline/corrected/maybe_message.go
@@ -29,20 +29,15 @@ type MaybeMessage struct{}
 // Apply implements [Rule]. It fails when maybemessage or true already names
 // something else in spec.
 func (r MaybeMessage) Apply(spec Specification) (Specification, error) {
-	for _, ref := range []model.Reference{maybeMessageRef, trueRef} {
-		if alreadyExists(spec, ref) {
-			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
-		}
+	definitions, err := r.definitions(spec.Definitions)
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing maybe message definitions: %w", err)
 	}
 	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing maybe message aliases: %w", err)
 	}
-	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
-	if err != nil {
-		return Specification{}, fmt.Errorf("introducing maybe message union: %w", err)
-	}
-	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	variants, err := r.variants(spec.Variants)
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing maybe message variants: %w", err)
 	}
@@ -51,67 +46,74 @@ func (r MaybeMessage) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting maybe message methods: %w", err)
 	}
 	return Specification{
-		Objects:        spec.Objects,
+		Definitions:    definitions,
 		Methods:        methods,
 		Fields:         spec.Fields,
 		Discriminators: spec.Discriminators,
-		Unions:         unions,
 		Variants:       variants,
 		Aliases:        aliases,
 		Release:        spec.Release,
 	}, nil
 }
 
-// aliases returns the table of primitive aliases MaybeMessage's variants
-// need: True, which the documentation writes as a bare keyword, not a named
-// type.
-func (r MaybeMessage) aliases() Aliases {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](1)
-	out.Insert(trueRef, Alias{
-		Ref:  trueRef,
-		Name: "True",
-		Type: typeexpr.NewPrimitive(primitive.True),
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
-			"True represents the boolean true value in Telegram API responses.",
-			prose.StylePlain,
-		))),
-	})
-	return out
-}
-
-// union returns the table holding the single MaybeMessage union definition.
-func (r MaybeMessage) union() parsed.Unions {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
-	out.Insert(maybeMessageRef, parsed.Union{
-		Ref:  maybeMessageRef,
-		Name: "MaybeMessage",
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+// definitions returns base holding what MaybeMessage names too: the union
+// itself and the True alias its variant stands for, which the documentation
+// writes as a bare keyword rather than a named type. It fails when either
+// reference is taken.
+func (r MaybeMessage) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+	out := NewDefinitionTable(base)
+	err := out.Insert(
+		maybeMessageRef,
+		"MaybeMessage",
+		model.DefinitionKindUnion,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
 			"MaybeMessage represents a method return value that is either an "+
 				"edited Message or True for inline messages.",
 			prose.StylePlain,
 		))),
-	})
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the maybe message union: %w", err)
+	}
+	err = out.Insert(
+		trueRef,
+		"True",
+		model.DefinitionKindAlias,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"True represents the boolean true value in Telegram API responses.",
+			prose.StylePlain,
+		))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the true alias: %w", err)
+	}
+	return out, nil
+}
+
+// aliases returns the type the True alias stands for.
+func (r MaybeMessage) aliases() Aliases {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](1)
+	out.Insert(trueRef, Alias{Ref: trueRef, Type: typeexpr.NewPrimitive(primitive.True)})
 	return out
 }
 
-// variants returns the table of MaybeMessage's two variants, message and
-// true.
-func (r MaybeMessage) variants() parsed.Variants {
-	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](2)
-	out.Insert(
-		model.VariantKey{Owner: maybeMessageRef, Ref: messageRef},
-		parsed.Variant{Ref: messageRef},
+// variants returns base listing MaybeMessage's two variants, message and true.
+// It fails when the union already lists either.
+func (r MaybeMessage) variants(base parsed.Variants) (parsed.Variants, error) {
+	out := NewVariantTable(base, maybeMessageRef)
+	err := out.Insert(
+		messageRef,
+		trueRef,
 	)
-	out.Insert(
-		model.VariantKey{Owner: maybeMessageRef, Ref: trueRef},
-		parsed.Variant{Ref: trueRef},
-	)
-	return out
+	if err != nil {
+		return nil, fmt.Errorf("listing maybe message variants: %w", err)
+	}
+	return out, nil
 }
 
-// maybeMessageMapping is a [pipeline.Mapping] that redirects a method
-// returning the Message-or-True union to MaybeMessage; every other method
-// rides through unchanged.
+// maybeMessageMapping is a [pipeline.Mapping] that redirects a method returning
+// the Message-or-True union to MaybeMessage; every other method rides through
+// unchanged.
 type maybeMessageMapping struct{}
 
 // Apply implements [pipeline.Mapping]. It never fails.
@@ -123,9 +125,7 @@ func (maybeMessageMapping) Apply(method resolved.Method) (resolved.Method, error
 		return method, nil
 	}
 	return resolved.Method{
-		Ref:         method.Ref,
-		Name:        method.Name,
-		Description: method.Description,
-		Type:        typeexpr.NewNamed(maybeMessageRef),
+		Ref:  method.Ref,
+		Type: typeexpr.NewNamed(maybeMessageRef),
 	}, nil
 }

--- a/model/pipeline/corrected/reply_markup.go
+++ b/model/pipeline/corrected/reply_markup.go
@@ -30,17 +30,11 @@ type ReplyMarkup struct{}
 // Apply implements [Rule]. It fails when replymarkup already names something
 // else in spec.
 func (r ReplyMarkup) Apply(spec Specification) (Specification, error) {
-	if alreadyExists(spec, replyMarkupRef) {
-		return Specification{}, fmt.Errorf(
-			"%s already names something else in spec",
-			replyMarkupRef,
-		)
-	}
-	unions, err := pipeline.NewMergedTable(spec.Unions, r.union()).Apply()
+	definitions, err := r.definitions(spec.Definitions)
 	if err != nil {
-		return Specification{}, fmt.Errorf("introducing reply markup union: %w", err)
+		return Specification{}, fmt.Errorf("introducing reply markup definitions: %w", err)
 	}
-	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	variants, err := r.variants(spec.Variants)
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing reply markup variants: %w", err)
 	}
@@ -49,52 +43,50 @@ func (r ReplyMarkup) Apply(spec Specification) (Specification, error) {
 		return Specification{}, fmt.Errorf("redirecting reply markup fields: %w", err)
 	}
 	return Specification{
-		Objects:        spec.Objects,
+		Definitions:    definitions,
 		Methods:        spec.Methods,
 		Fields:         fields,
 		Discriminators: spec.Discriminators,
-		Unions:         unions,
 		Variants:       variants,
 		Aliases:        spec.Aliases,
 		Release:        spec.Release,
 	}, nil
 }
 
-// union returns the table holding the single ReplyMarkup union definition.
-func (r ReplyMarkup) union() parsed.Unions {
-	out := pipeline.NewMapTableWithCapacity[model.Reference, parsed.Union](1)
-	out.Insert(replyMarkupRef, parsed.Union{
-		Ref:  replyMarkupRef,
-		Name: "ReplyMarkup",
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
+// definitions returns base holding what ReplyMarkup names too: the union
+// itself. Its variants are documented objects and name themselves. It fails
+// when the reference is taken.
+func (r ReplyMarkup) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+	out := NewDefinitionTable(base)
+	err := out.Insert(
+		replyMarkupRef,
+		"ReplyMarkup",
+		model.DefinitionKindUnion,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
 			"ReplyMarkup represents a reply markup attached to a message.",
 			prose.StylePlain,
 		))),
-	})
-	return out
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the reply markup union: %w", err)
+	}
+	return out, nil
 }
 
-// variants returns the table of ReplyMarkup's four variants, each already a
-// documented object.
-func (r ReplyMarkup) variants() parsed.Variants {
-	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](4)
-	out.Insert(
-		model.VariantKey{Owner: replyMarkupRef, Ref: inlineKeyboardMarkupRef},
-		parsed.Variant{Ref: inlineKeyboardMarkupRef},
+// variants returns base listing ReplyMarkup's four variants, each already a
+// documented object. It fails when the union already lists one of them.
+func (r ReplyMarkup) variants(base parsed.Variants) (parsed.Variants, error) {
+	out := NewVariantTable(base, replyMarkupRef)
+	err := out.Insert(
+		inlineKeyboardMarkupRef,
+		replyKeyboardMarkupRef,
+		replyKeyboardRemoveRef,
+		forceReplyRef,
 	)
-	out.Insert(
-		model.VariantKey{Owner: replyMarkupRef, Ref: replyKeyboardMarkupRef},
-		parsed.Variant{Ref: replyKeyboardMarkupRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: replyMarkupRef, Ref: replyKeyboardRemoveRef},
-		parsed.Variant{Ref: replyKeyboardRemoveRef},
-	)
-	out.Insert(
-		model.VariantKey{Owner: replyMarkupRef, Ref: forceReplyRef},
-		parsed.Variant{Ref: forceReplyRef},
-	)
-	return out
+	if err != nil {
+		return nil, fmt.Errorf("listing reply markup variants: %w", err)
+	}
+	return out, nil
 }
 
 // replyMarkupMapping is a [pipeline.Mapping] that redirects a field typed as

--- a/model/pipeline/corrected/rich_text.go
+++ b/model/pipeline/corrected/rich_text.go
@@ -29,67 +29,87 @@ type RichText struct{}
 // Apply implements [Rule]. It fails when richtextplain or richtextsequence
 // already names something else in spec.
 func (r RichText) Apply(spec Specification) (Specification, error) {
-	for _, ref := range []model.Reference{richTextPlainRef, richTextSequenceRef} {
-		if alreadyExists(spec, ref) {
-			return Specification{}, fmt.Errorf("%s already names something else in spec", ref)
-		}
+	definitions, err := r.definitions(spec.Definitions)
+	if err != nil {
+		return Specification{}, fmt.Errorf("introducing rich text definitions: %w", err)
 	}
 	aliases, err := pipeline.NewMergedTable(spec.Aliases, r.aliases()).Apply()
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing rich text aliases: %w", err)
 	}
-	variants, err := pipeline.NewMergedTable(spec.Variants, r.variants()).Apply()
+	variants, err := r.variants(spec.Variants)
 	if err != nil {
 		return Specification{}, fmt.Errorf("introducing rich text variants: %w", err)
 	}
 	return Specification{
-		Objects:        spec.Objects,
+		Definitions:    definitions,
 		Methods:        spec.Methods,
 		Fields:         spec.Fields,
 		Discriminators: spec.Discriminators,
-		Unions:         spec.Unions,
 		Variants:       variants,
 		Aliases:        aliases,
 		Release:        spec.Release,
 	}, nil
 }
 
-// aliases returns the table of RichText's two prose-only variants: a plain
-// string, and an array of RichText itself.
+// definitions returns base holding what RichText names too: the two variants
+// the documentation writes as prose rather than as list items. It fails when
+// either reference is taken.
+func (r RichText) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+	out := NewDefinitionTable(base)
+	err := out.Insert(
+		richTextPlainRef,
+		"RichTextPlain",
+		model.DefinitionKindAlias,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"RichTextPlain represents the plain-text variant of a RichText value.",
+			prose.StylePlain,
+		))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the rich text plain alias: %w", err)
+	}
+	err = out.Insert(
+		richTextSequenceRef,
+		"RichTextSequence",
+		model.DefinitionKindAlias,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"RichTextSequence represents the nested-array variant of a RichText value.",
+			prose.StylePlain,
+		))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the rich text sequence alias: %w", err)
+	}
+	return out, nil
+}
+
+// aliases returns the type each RichText variant stands for: a plain string,
+// and an array of RichText itself.
 func (r RichText) aliases() Aliases {
 	out := pipeline.NewMapTableWithCapacity[model.Reference, Alias](2)
 	out.Insert(richTextPlainRef, Alias{
 		Ref:  richTextPlainRef,
-		Name: "RichTextPlain",
 		Type: typeexpr.NewPrimitive(primitive.String),
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
-			"RichTextPlain represents the plain-text variant of a RichText value.",
-			prose.StylePlain,
-		))),
 	})
 	out.Insert(richTextSequenceRef, Alias{
 		Ref:  richTextSequenceRef,
-		Name: "RichTextSequence",
 		Type: typeexpr.NewArray(typeexpr.NewNamed(richTextRef)),
-		Description: prose.NewPassage(prose.NewParagraph(prose.NewText(
-			"RichTextSequence represents the nested-array variant of a RichText value.",
-			prose.StylePlain,
-		))),
 	})
 	return out
 }
 
-// variants returns the table of RichTextPlain and RichTextSequence as
-// variants of the documented RichText union.
-func (r RichText) variants() parsed.Variants {
-	out := pipeline.NewMapTableWithCapacity[model.VariantKey, parsed.Variant](2)
-	out.Insert(
-		model.VariantKey{Owner: richTextRef, Ref: richTextPlainRef},
-		parsed.Variant{Ref: richTextPlainRef},
+// variants returns base listing RichTextPlain and RichTextSequence as variants
+// of the documented RichText union too, after the ones it already lists. It
+// fails when the union already lists either.
+func (r RichText) variants(base parsed.Variants) (parsed.Variants, error) {
+	out := NewVariantTable(base, richTextRef)
+	err := out.Insert(
+		richTextPlainRef,
+		richTextSequenceRef,
 	)
-	out.Insert(
-		model.VariantKey{Owner: richTextRef, Ref: richTextSequenceRef},
-		parsed.Variant{Ref: richTextSequenceRef},
-	)
-	return out
+	if err != nil {
+		return nil, fmt.Errorf("listing rich text variants: %w", err)
+	}
+	return out, nil
 }

--- a/model/pipeline/corrected/specification.go
+++ b/model/pipeline/corrected/specification.go
@@ -5,6 +5,10 @@
 // resolved specification: it introduces union and alias definitions the
 // documentation does not name, and redirects matching field or method types
 // to them.
+//
+// A definition tgen introduces has no place on the page, so it stands after
+// every definition the page provides, in the order the rules run. Positions
+// downstream of this stage therefore no longer index the page's headings.
 package corrected
 
 import (
@@ -18,7 +22,8 @@ import (
 	"github.com/andreychh/tgen/model/pipeline/typed"
 )
 
-// Aliases is the table of tgen-introduced aliases, keyed by reference.
+// Aliases is the table of what each alias has of its own, keyed by reference.
+// Only a definition of alias kind has a record here.
 type Aliases = pipeline.Table[model.Reference, Alias]
 
 // Specification is the database after tgen's own corrections are applied on
@@ -26,11 +31,10 @@ type Aliases = pipeline.Table[model.Reference, Alias]
 // the documentation does not name, and redirect matching field or method
 // types to them.
 type Specification struct {
-	Objects        parsed.Objects
+	Definitions    parsed.Definitions
 	Methods        resolved.Methods
 	Fields         typed.Fields
 	Discriminators classified.Discriminators
-	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Aliases        Aliases
 	Release        parsed.Release
@@ -62,11 +66,10 @@ func NewPass(spec resolved.Specification) Pass {
 // fails when any rule fails.
 func (p Pass) Specification() (Specification, error) {
 	spec := Specification{
-		Objects:        p.spec.Objects,
+		Definitions:    p.spec.Definitions,
 		Methods:        p.spec.Methods,
 		Fields:         p.spec.Fields,
 		Discriminators: p.spec.Discriminators,
-		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,
 		Aliases:        pipeline.NewMapTable[model.Reference, Alias](),
 		Release:        p.spec.Release,
@@ -88,21 +91,4 @@ func (p Pass) Specification() (Specification, error) {
 		spec = next
 	}
 	return spec, nil
-}
-
-// alreadyExists reports whether ref already names an object, method, union, or
-// alias in spec. Methods count: a target renders each one as a type, so a
-// method and a union sharing a reference collide there.
-func alreadyExists(spec Specification, ref model.Reference) bool {
-	if _, ok := spec.Objects.Lookup(ref); ok {
-		return true
-	}
-	if _, ok := spec.Methods.Lookup(ref); ok {
-		return true
-	}
-	if _, ok := spec.Unions.Lookup(ref); ok {
-		return true
-	}
-	_, ok := spec.Aliases.Lookup(ref)
-	return ok
 }

--- a/model/pipeline/corrected/variant_table.go
+++ b/model/pipeline/corrected/variant_table.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package corrected
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+)
+
+// VariantTable is the variants table a rule writes into, bound to the union it
+// writes about: it places every variant inserted after all the variants that
+// union already lists, so a rule states which types the union accepts and in
+// which order, never a position. Its zero value is not usable; construct one
+// with [NewVariantTable].
+type VariantTable struct {
+	base  parsed.Variants
+	owner model.Reference
+	added pipeline.MapTable[model.VariantKey, parsed.Variant]
+}
+
+// NewVariantTable constructs a VariantTable over the variants base already
+// holds, writing about the union owner.
+func NewVariantTable(base parsed.Variants, owner model.Reference) VariantTable {
+	return VariantTable{
+		base:  base,
+		owner: owner,
+		added: pipeline.NewMapTable[model.VariantKey, parsed.Variant](),
+	}
+}
+
+// Insert admits the types the union accepts, each at the place after every
+// variant the union already lists, in the order given. It fails when the union
+// already lists one of them.
+func (t VariantTable) Insert(refs ...model.Reference) error {
+	for _, ref := range refs {
+		key := model.VariantKey{Owner: t.owner, Ref: ref}
+		if _, exists := t.Lookup(key); exists {
+			return fmt.Errorf("%s already lists %s", t.owner, ref)
+		}
+		t.added.Insert(key, parsed.Variant{Ref: ref, Position: t.place()})
+	}
+	return nil
+}
+
+func (t VariantTable) Lookup(key model.VariantKey) (parsed.Variant, bool) {
+	if variant, exists := t.added.Lookup(key); exists {
+		return variant, true
+	}
+	return t.base.Lookup(key)
+}
+
+func (t VariantTable) Count() int {
+	return t.base.Count() + t.added.Count()
+}
+
+func (t VariantTable) All() iter.Seq2[model.VariantKey, parsed.Variant] {
+	return func(yield func(model.VariantKey, parsed.Variant) bool) {
+		for key, variant := range t.base.All() {
+			if !yield(key, variant) {
+				return
+			}
+		}
+		for key, variant := range t.added.All() {
+			if !yield(key, variant) {
+				return
+			}
+		}
+	}
+}
+
+// place returns the position the next variant inserted takes: the one after
+// every variant this table's union lists. Variants of other unions do not
+// count, since each union numbers its own from zero.
+func (t VariantTable) place() model.Position {
+	next := model.Position(0)
+	for key, variant := range t.All() {
+		if key.Owner != t.owner {
+			continue
+		}
+		next = max(next, variant.Position+1)
+	}
+	return next
+}

--- a/model/pipeline/flattened/alias.go
+++ b/model/pipeline/flattened/alias.go
@@ -8,17 +8,13 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline/corrected"
-	"github.com/andreychh/tgen/model/prose"
 	"github.com/andreychh/tgen/model/typeform"
 )
 
-// Alias is a name tgen introduces for a type the documentation leaves unnamed.
-// Its type is reduced to a flat one.
+// Alias is the type a name tgen introduces stands for, reduced to a flat one.
 type Alias struct {
-	Ref         model.Reference
-	Name        model.Name
-	Type        typeform.Type
-	Description prose.Passage
+	Ref  model.Reference
+	Type typeform.Type
 }
 
 // AliasMapping maps a corrected alias into a flattened one by reducing its type
@@ -38,9 +34,7 @@ func (m AliasMapping) Apply(alias corrected.Alias) (Alias, error) {
 		return Alias{}, fmt.Errorf("narrowing alias type: %w", err)
 	}
 	return Alias{
-		Ref:         alias.Ref,
-		Name:        alias.Name,
-		Type:        typ,
-		Description: alias.Description,
+		Ref:  alias.Ref,
+		Type: typ,
 	}, nil
 }

--- a/model/pipeline/flattened/method.go
+++ b/model/pipeline/flattened/method.go
@@ -8,21 +8,18 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline/resolved"
-	"github.com/andreychh/tgen/model/prose"
 	"github.com/andreychh/tgen/model/typeform"
 )
 
-// Method is the record of a documentation method whose return type is reduced
-// to a flat one: its reference, name, description, and the type it returns.
+// Method is what a method has of its own, with the type it returns reduced to a
+// flat one.
 type Method struct {
-	Ref         model.Reference
-	Name        model.Name
-	Description prose.Passage
-	Type        typeform.Type
+	Ref  model.Reference
+	Type typeform.Type
 }
 
-// MethodMapping maps a resolved method into a flattened one by reducing its
-// return type to a flat type.
+// MethodMapping maps a resolved method into a flattened one by reducing the
+// type it returns to a flat one.
 type MethodMapping struct{}
 
 // NewMethodMapping constructs a MethodMapping.
@@ -30,17 +27,15 @@ func NewMethodMapping() MethodMapping {
 	return MethodMapping{}
 }
 
-// Apply implements [pipeline.Mapping]. It fails when the method's return type
-// holds a union.
+// Apply implements [pipeline.Mapping]. It fails when the return type holds a
+// union.
 func (m MethodMapping) Apply(method resolved.Method) (Method, error) {
 	typ, err := NewNarrowing(method.Type).Value()
 	if err != nil {
 		return Method{}, fmt.Errorf("narrowing return type: %w", err)
 	}
 	return Method{
-		Ref:         method.Ref,
-		Name:        method.Name,
-		Description: method.Description,
-		Type:        typ,
+		Ref:  method.Ref,
+		Type: typ,
 	}, nil
 }

--- a/model/pipeline/flattened/specification.go
+++ b/model/pipeline/flattened/specification.go
@@ -20,21 +20,20 @@ import (
 // key.
 type Fields = pipeline.Table[model.FieldKey, Field]
 
-// Methods is the table of flattened methods, keyed by reference.
+// Methods is the table of what each method has of its own, keyed by reference.
 type Methods = pipeline.Table[model.Reference, Method]
 
-// Aliases is the table of flattened aliases, keyed by reference.
+// Aliases is the table of what each alias has of its own, keyed by reference.
 type Aliases = pipeline.Table[model.Reference, Alias]
 
 // Specification is the database after every type is reduced to a flat one. The
-// object, discriminator, union, and variant tables and the release ride through
+// definition, discriminator, and variant tables and the release ride through
 // from the corrected stage unchanged.
 type Specification struct {
-	Objects        parsed.Objects
+	Definitions    parsed.Definitions
 	Methods        Methods
 	Fields         Fields
 	Discriminators classified.Discriminators
-	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Aliases        Aliases
 	Release        parsed.Release
@@ -67,11 +66,10 @@ func (p Pass) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("flattening aliases: %w", err)
 	}
 	return Specification{
-		Objects:        p.spec.Objects,
+		Definitions:    p.spec.Definitions,
 		Methods:        methods,
 		Fields:         fields,
 		Discriminators: p.spec.Discriminators,
-		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,
 		Aliases:        aliases,
 		Release:        p.spec.Release,

--- a/model/pipeline/parsed/definition.go
+++ b/model/pipeline/parsed/definition.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package parsed
+
+import (
+	"github.com/andreychh/tgen/model"
+	prosetree "github.com/andreychh/tgen/model/prose"
+)
+
+// Definition is the decoded record of anything the page names, whatever its
+// kind: its reference, name, kind, position, and description. What a
+// definition owns — the fields of an object, the parameters of a method, the
+// variants of a union — forms tables of its own.
+type Definition struct {
+	Ref         model.Reference
+	Name        model.Name
+	Kind        model.DefinitionKind
+	Position    model.Position
+	Description prosetree.Passage
+}
+
+// KindFilter is a [pipeline.Filter] that narrows a definitions table to the
+// definitions of one kind.
+type KindFilter struct {
+	kind model.DefinitionKind
+}
+
+// NewKindFilter constructs a KindFilter keeping the definitions of kind.
+func NewKindFilter(kind model.DefinitionKind) KindFilter {
+	return KindFilter{kind: kind}
+}
+
+// Apply implements [pipeline.Filter]. It reports whether definition is of the
+// kind the filter keeps.
+func (f KindFilter) Apply(_ model.Reference, definition Definition) bool {
+	return definition.Kind == f.kind
+}

--- a/model/pipeline/parsed/method.go
+++ b/model/pipeline/parsed/method.go
@@ -11,48 +11,43 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
 	"github.com/andreychh/tgen/model/pipeline/parsed/prose"
-	prosetree "github.com/andreychh/tgen/model/prose"
 )
 
-// Method is the decoded record of a documentation method: its reference, name,
-// and description. Its parameters form a separate table.
-type Method struct {
-	Ref         model.Reference
-	Name        model.Name
-	Description prosetree.Passage
-}
-
 // MethodSection is one method's section of the documentation page, headed by
-// its <h4>.
+// its <h4> at its position among the page's headings.
 type MethodSection struct {
+	at int
 	h4 *goquery.Selection
 }
 
-// NewMethodSection constructs a MethodSection over a method's <h4> header.
-func NewMethodSection(h4 *goquery.Selection) MethodSection {
-	return MethodSection{h4: h4}
+// NewMethodSection constructs a MethodSection over a method's <h4> header at
+// position at.
+func NewMethodSection(at int, h4 *goquery.Selection) MethodSection {
+	return MethodSection{at: at, h4: h4}
 }
 
-// Record returns the method decoded from the section: its reference, name, and
-// description. The return type stays inside the description prose for a later
-// pass to interpret. It fails when the reference, name, or description is
-// malformed.
-func (s MethodSection) Record() (Method, error) {
+// Record returns the method decoded from the section as a definition of method
+// kind: its reference, name, position, and description. The return type stays
+// inside the description prose for a later pass to interpret. It fails when the
+// reference, name, or description is malformed.
+func (s MethodSection) Record() (Definition, error) {
 	ref, err := NewReference(s.h4).Value()
 	if err != nil {
-		return Method{}, fmt.Errorf("parsing method reference: %w", err)
+		return Definition{}, fmt.Errorf("parsing method reference: %w", err)
 	}
 	name, err := NewMethodName(s.h4).Value()
 	if err != nil {
-		return Method{}, fmt.Errorf("parsing method name: %w", err)
+		return Definition{}, fmt.Errorf("parsing method name: %w", err)
 	}
 	description, err := prose.NewPassage(s.h4.NextUntil("h3, h4, hr").Not("table.table")).Value()
 	if err != nil {
-		return Method{}, fmt.Errorf("parsing method description: %w", err)
+		return Definition{}, fmt.Errorf("parsing method description: %w", err)
 	}
-	return Method{
+	return Definition{
 		Ref:         ref,
 		Name:        name,
+		Kind:        model.DefinitionKindMethod,
+		Position:    model.Position(s.at),
 		Description: description,
 	}, nil
 }
@@ -68,15 +63,16 @@ func NewMethodSections(doc *goquery.Document) MethodSections {
 	return MethodSections{doc: doc}
 }
 
-// Table returns the methods table, one record per method section. It fails when
-// any method section is malformed.
-func (s MethodSections) Table() (pipeline.MapTable[model.Reference, Method], error) {
-	out := pipeline.NewMapTable[model.Reference, Method]()
-	for _, h4 := range s.doc.Find("h4").EachIter() {
+// Table returns the definitions of method kind, one record per method section,
+// each holding the position of its heading among the page's headings. It fails
+// when any method section is malformed.
+func (s MethodSections) Table() (pipeline.MapTable[model.Reference, Definition], error) {
+	out := pipeline.NewMapTable[model.Reference, Definition]()
+	for at, h4 := range s.doc.Find("h4").EachIter() {
 		if NewHeading(h4).Kind() != KindMethod {
 			continue
 		}
-		method, err := NewMethodSection(h4).Record()
+		method, err := NewMethodSection(at, h4).Record()
 		if err != nil {
 			return out, fmt.Errorf("parsing method: %w", err)
 		}

--- a/model/pipeline/parsed/object.go
+++ b/model/pipeline/parsed/object.go
@@ -11,48 +11,43 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
 	"github.com/andreychh/tgen/model/pipeline/parsed/prose"
-	prosetree "github.com/andreychh/tgen/model/prose"
 )
 
-// Object is the decoded record of a documentation object: its reference, name,
-// and description. Its fields form a separate table.
-type Object struct {
-	Ref         model.Reference
-	Name        model.Name
-	Description prosetree.Passage
-}
-
 // ObjectSection is one object's section of the documentation page, headed by
-// its <h4>.
+// its <h4> at its position among the page's headings.
 type ObjectSection struct {
+	at int
 	h4 *goquery.Selection
 }
 
-// NewObjectSection constructs an ObjectSection over an object's <h4> header.
-func NewObjectSection(h4 *goquery.Selection) ObjectSection {
-	return ObjectSection{h4: h4}
+// NewObjectSection constructs an ObjectSection over an object's <h4> header at
+// position at.
+func NewObjectSection(at int, h4 *goquery.Selection) ObjectSection {
+	return ObjectSection{at: at, h4: h4}
 }
 
-// Record returns the object decoded from the section: its reference, name, and
-// description. The description is the section's prose minus its field table, so
-// notes after the table are kept. It fails when the reference, name, or
-// description is malformed.
-func (s ObjectSection) Record() (Object, error) {
+// Record returns the object decoded from the section as a definition of object
+// kind: its reference, name, position, and description. The description is the
+// section's prose minus its field table, so notes after the table are kept. It
+// fails when the reference, name, or description is malformed.
+func (s ObjectSection) Record() (Definition, error) {
 	ref, err := NewReference(s.h4).Value()
 	if err != nil {
-		return Object{}, fmt.Errorf("parsing object reference: %w", err)
+		return Definition{}, fmt.Errorf("parsing object reference: %w", err)
 	}
 	name, err := NewTypeName(s.h4).Value()
 	if err != nil {
-		return Object{}, fmt.Errorf("parsing object name: %w", err)
+		return Definition{}, fmt.Errorf("parsing object name: %w", err)
 	}
 	description, err := prose.NewPassage(s.h4.NextUntil("h3, h4, hr").Not("table.table")).Value()
 	if err != nil {
-		return Object{}, fmt.Errorf("parsing object description: %w", err)
+		return Definition{}, fmt.Errorf("parsing object description: %w", err)
 	}
-	return Object{
+	return Definition{
 		Ref:         ref,
 		Name:        name,
+		Kind:        model.DefinitionKindObject,
+		Position:    model.Position(s.at),
 		Description: description,
 	}, nil
 }
@@ -68,15 +63,16 @@ func NewObjectSections(doc *goquery.Document) ObjectSections {
 	return ObjectSections{doc: doc}
 }
 
-// Table returns the objects table, one record per object section. It fails when
-// any object section is malformed.
-func (s ObjectSections) Table() (pipeline.MapTable[model.Reference, Object], error) {
-	out := pipeline.NewMapTable[model.Reference, Object]()
-	for _, h4 := range s.doc.Find("h4").EachIter() {
+// Table returns the definitions of object kind, one record per object section,
+// each holding the position of its heading among the page's headings. It fails
+// when any object section is malformed.
+func (s ObjectSections) Table() (pipeline.MapTable[model.Reference, Definition], error) {
+	out := pipeline.NewMapTable[model.Reference, Definition]()
+	for at, h4 := range s.doc.Find("h4").EachIter() {
 		if NewHeading(h4).Kind() != KindObject {
 			continue
 		}
-		object, err := NewObjectSection(h4).Record()
+		object, err := NewObjectSection(at, h4).Record()
 		if err != nil {
 			return out, fmt.Errorf("parsing object: %w", err)
 		}

--- a/model/pipeline/parsed/specification.go
+++ b/model/pipeline/parsed/specification.go
@@ -12,38 +12,36 @@ import (
 	"github.com/andreychh/tgen/model/pipeline"
 )
 
-// Objects represents the table of standalone objects, keyed by reference.
-type Objects = pipeline.Table[model.Reference, Object]
+// Definitions represents the table of everything the page names — objects,
+// methods, and unions alike — keyed by reference. A reference names at most
+// one definition whatever its kind. Positions index the page's headings, so
+// definitions of different kinds compare in the order the page presents them.
+type Definitions = pipeline.Table[model.Reference, Definition]
 
 // Fields represents the table of object fields, keyed by owner reference and
-// field key.
+// field key. Positions are zero-based, unique and gapless within one owner's
+// fields.
 type Fields = pipeline.Table[model.FieldKey, Field]
 
-// Methods represents the table of API methods, keyed by reference.
-type Methods = pipeline.Table[model.Reference, Method]
-
 // Params represents the table of method parameters, keyed by owner reference
-// and parameter key.
+// and parameter key. Positions are zero-based, unique and gapless within one
+// owner's parameters.
 type Params = pipeline.Table[model.FieldKey, Param]
 
-// Unions represents the table of discriminated unions, keyed by reference.
-type Unions = pipeline.Table[model.Reference, Union]
-
 // Variants represents the table of union variants, keyed by owner reference and
-// variant reference.
+// variant reference. Positions are zero-based, unique and gapless within one
+// union's variants.
 type Variants = pipeline.Table[model.VariantKey, Variant]
 
 // Specification is the initial database: tables transcribed straight from the
 // page, before any interpretation. Fields and parameters are keyed by their
 // owner's reference and their own key.
 type Specification struct {
-	Objects  Objects
-	Fields   Fields
-	Methods  Methods
-	Params   Params
-	Unions   Unions
-	Variants Variants
-	Release  Release
+	Definitions Definitions
+	Fields      Fields
+	Params      Params
+	Variants    Variants
+	Release     Release
 }
 
 // Page is a parsed documentation page, the source of a Specification.
@@ -56,29 +54,21 @@ func NewPage(doc *goquery.Document) Page {
 	return Page{doc: doc}
 }
 
-// Specification returns the database decoded from the page: the object, field,
-// method, parameter, union, and variant tables, plus the latest release. It
-// fails when any section is malformed.
+// Specification returns the database decoded from the page: the definition,
+// field, parameter, and variant tables, plus the latest release. It fails when
+// any section is malformed or when two definitions share a reference.
 func (p Page) Specification() (Specification, error) {
-	objects, err := NewObjectSections(p.doc).Table()
+	definitions, err := p.definitions()
 	if err != nil {
-		return Specification{}, fmt.Errorf("decoding objects: %w", err)
+		return Specification{}, fmt.Errorf("decoding definitions: %w", err)
 	}
 	fields, err := NewFieldRows(p.doc).Table()
 	if err != nil {
 		return Specification{}, fmt.Errorf("decoding fields: %w", err)
 	}
-	methods, err := NewMethodSections(p.doc).Table()
-	if err != nil {
-		return Specification{}, fmt.Errorf("decoding methods: %w", err)
-	}
 	params, err := NewParamRows(p.doc).Table()
 	if err != nil {
 		return Specification{}, fmt.Errorf("decoding parameters: %w", err)
-	}
-	unions, err := NewUnionSections(p.doc).Table()
-	if err != nil {
-		return Specification{}, fmt.Errorf("decoding unions: %w", err)
 	}
 	variants, err := NewVariantItems(p.doc).Table()
 	if err != nil {
@@ -89,12 +79,37 @@ func (p Page) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("decoding release: %w", err)
 	}
 	return Specification{
-		Objects:  objects,
-		Fields:   fields,
-		Methods:  methods,
-		Params:   params,
-		Unions:   unions,
-		Variants: variants,
-		Release:  release,
+		Definitions: definitions,
+		Fields:      fields,
+		Params:      params,
+		Variants:    variants,
+		Release:     release,
 	}, nil
+}
+
+// definitions returns the object, method, and union sections gathered into one
+// key space. It fails when any section is malformed or when two of them share a
+// reference, since a reference names at most one definition.
+func (p Page) definitions() (Definitions, error) {
+	objects, err := NewObjectSections(p.doc).Table()
+	if err != nil {
+		return nil, fmt.Errorf("decoding objects: %w", err)
+	}
+	methods, err := NewMethodSections(p.doc).Table()
+	if err != nil {
+		return nil, fmt.Errorf("decoding methods: %w", err)
+	}
+	unions, err := NewUnionSections(p.doc).Table()
+	if err != nil {
+		return nil, fmt.Errorf("decoding unions: %w", err)
+	}
+	named, err := pipeline.NewMergedTable(objects, methods).Apply()
+	if err != nil {
+		return nil, fmt.Errorf("gathering object and method definitions: %w", err)
+	}
+	gathered, err := pipeline.NewMergedTable(named, unions).Apply()
+	if err != nil {
+		return nil, fmt.Errorf("gathering union definitions: %w", err)
+	}
+	return gathered, nil
 }

--- a/model/pipeline/parsed/union.go
+++ b/model/pipeline/parsed/union.go
@@ -11,47 +11,43 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
 	"github.com/andreychh/tgen/model/pipeline/parsed/prose"
-	prosetree "github.com/andreychh/tgen/model/prose"
 )
 
-// Union is the decoded record of a documentation union: its reference, name,
-// and description. Its variants form a separate table.
-type Union struct {
-	Ref         model.Reference
-	Name        model.Name
-	Description prosetree.Passage
-}
-
 // UnionSection is one union's section of the documentation page, headed by its
-// <h4>.
+// <h4> at its position among the page's headings.
 type UnionSection struct {
+	at int
 	h4 *goquery.Selection
 }
 
-// NewUnionSection constructs a UnionSection over a union's <h4> header.
-func NewUnionSection(h4 *goquery.Selection) UnionSection {
-	return UnionSection{h4: h4}
+// NewUnionSection constructs a UnionSection over a union's <h4> header at
+// position at.
+func NewUnionSection(at int, h4 *goquery.Selection) UnionSection {
+	return UnionSection{at: at, h4: h4}
 }
 
-// Record returns the union decoded from the section: its reference, name, and
-// description. The description is the section's prose minus its variant list.
-// It fails when the reference, name, or description is malformed.
-func (s UnionSection) Record() (Union, error) {
+// Record returns the union decoded from the section as a definition of union
+// kind: its reference, name, position, and description. The description is the
+// section's prose minus its variant list. It fails when the reference, name, or
+// description is malformed.
+func (s UnionSection) Record() (Definition, error) {
 	ref, err := NewReference(s.h4).Value()
 	if err != nil {
-		return Union{}, fmt.Errorf("parsing union reference: %w", err)
+		return Definition{}, fmt.Errorf("parsing union reference: %w", err)
 	}
 	name, err := NewTypeName(s.h4).Value()
 	if err != nil {
-		return Union{}, fmt.Errorf("parsing union name: %w", err)
+		return Definition{}, fmt.Errorf("parsing union name: %w", err)
 	}
 	description, err := prose.NewPassage(s.h4.NextUntil("h3, h4, hr").Not("ul")).Value()
 	if err != nil {
-		return Union{}, fmt.Errorf("parsing union description: %w", err)
+		return Definition{}, fmt.Errorf("parsing union description: %w", err)
 	}
-	return Union{
+	return Definition{
 		Ref:         ref,
 		Name:        name,
+		Kind:        model.DefinitionKindUnion,
+		Position:    model.Position(s.at),
 		Description: description,
 	}, nil
 }
@@ -66,15 +62,16 @@ func NewUnionSections(doc *goquery.Document) UnionSections {
 	return UnionSections{doc: doc}
 }
 
-// Table returns the unions table, one record per union section. It fails when
-// any union section is malformed.
-func (s UnionSections) Table() (pipeline.MapTable[model.Reference, Union], error) {
-	out := pipeline.NewMapTable[model.Reference, Union]()
-	for _, h4 := range s.doc.Find("h4").EachIter() {
+// Table returns the definitions of union kind, one record per union section,
+// each holding the position of its heading among the page's headings. It fails
+// when any union section is malformed.
+func (s UnionSections) Table() (pipeline.MapTable[model.Reference, Definition], error) {
+	out := pipeline.NewMapTable[model.Reference, Definition]()
+	for at, h4 := range s.doc.Find("h4").EachIter() {
 		if NewHeading(h4).Kind() != KindUnion {
 			continue
 		}
-		union, err := NewUnionSection(h4).Record()
+		union, err := NewUnionSection(at, h4).Record()
 		if err != nil {
 			return out, fmt.Errorf("parsing union: %w", err)
 		}

--- a/model/pipeline/parsed/variant.go
+++ b/model/pipeline/parsed/variant.go
@@ -15,23 +15,29 @@ import (
 )
 
 // Variant is the decoded record of one union member: the reference of the type
-// it points to. Its owning union is the key.
+// it points to, and its position among the other members of the same union.
+// Its owning union is the key.
 type Variant struct {
-	Ref model.Reference
+	Ref      model.Reference
+	Position model.Position
 }
 
-// VariantItem is one variant's <li> item of a union's list.
+// VariantItem is one variant's <li> item of a union's list, at its position
+// among sibling items.
 type VariantItem struct {
+	at int
 	li *goquery.Selection
 }
 
-// NewVariantItem constructs a VariantItem over a variant's <li> item.
-func NewVariantItem(li *goquery.Selection) VariantItem {
-	return VariantItem{li: li}
+// NewVariantItem constructs a VariantItem over a variant's <li> item at
+// position at.
+func NewVariantItem(at int, li *goquery.Selection) VariantItem {
+	return VariantItem{at: at, li: li}
 }
 
-// Record returns the variant decoded from the item: the reference it points to.
-// It fails when the item has no link or the reference is malformed.
+// Record returns the variant decoded from the item: the reference it points to
+// and its position. It fails when the item has no link or the reference is
+// malformed.
 func (i VariantItem) Record() (Variant, error) {
 	href, found := i.li.Find("a").Attr("href")
 	if !found {
@@ -41,7 +47,7 @@ func (i VariantItem) Record() (Variant, error) {
 	if !refPattern.MatchString(ref) {
 		return Variant{}, fmt.Errorf("variant reference %q is malformed", ref)
 	}
-	return Variant{Ref: model.Reference(ref)}, nil
+	return Variant{Ref: model.Reference(ref), Position: model.Position(i.at)}, nil
 }
 
 // UnionVariants are the variant items declared under one union's heading.
@@ -63,8 +69,8 @@ func (v UnionVariants) Records() (model.Reference, []Variant, error) {
 	}
 	var variants []Variant
 	items := v.h4.NextUntil("h3, h4, hr").Filter("ul").First().Find("li")
-	for _, li := range items.EachIter() {
-		variant, err := NewVariantItem(li).Record()
+	for at, li := range items.EachIter() {
+		variant, err := NewVariantItem(at, li).Record()
 		if err != nil {
 			return "", nil, fmt.Errorf("parsing variant: %w", err)
 		}

--- a/model/pipeline/resolved/method.go
+++ b/model/pipeline/resolved/method.go
@@ -9,21 +9,19 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 	"github.com/andreychh/tgen/model/pipeline/resolved/types"
-	"github.com/andreychh/tgen/model/prose"
 	"github.com/andreychh/tgen/model/typeexpr"
 )
 
-// Method is the decoded record of a documentation method after its return type
-// is resolved: its reference, name, description, and the type it returns.
+// Method is what a method has of its own: the type it returns. Everything it
+// shares with any other definition — its name, position, and description —
+// stays in the definitions table.
 type Method struct {
-	Ref         model.Reference
-	Name        model.Name
-	Description prose.Passage
-	Type        typeexpr.Expression
+	Ref  model.Reference
+	Type typeexpr.Expression
 }
 
-// MethodMapping maps a parsed method into a resolved method by decoding its
-// return type from description prose into a type expression.
+// MethodMapping maps a method definition into what the method has of its own by
+// decoding the return type out of its description prose.
 type MethodMapping struct{}
 
 // NewMethodMapping constructs a MethodMapping.
@@ -31,17 +29,15 @@ func NewMethodMapping() MethodMapping {
 	return MethodMapping{}
 }
 
-// Apply implements [pipeline.Mapping]. It fails when the method's description
-// prose does not contain a recognizable return clause.
-func (m MethodMapping) Apply(method parsed.Method) (Method, error) {
-	expr, err := types.NewReturnType(method.Description).Value()
+// Apply implements [pipeline.Mapping]. It fails when the definition's
+// description prose does not contain a recognizable return clause.
+func (m MethodMapping) Apply(definition parsed.Definition) (Method, error) {
+	expr, err := types.NewReturnType(definition.Description).Value()
 	if err != nil {
 		return Method{}, fmt.Errorf("decoding return type: %w", err)
 	}
 	return Method{
-		Ref:         method.Ref,
-		Name:        method.Name,
-		Description: method.Description,
-		Type:        expr,
+		Ref:  definition.Ref,
+		Type: expr,
 	}, nil
 }

--- a/model/pipeline/resolved/specification.go
+++ b/model/pipeline/resolved/specification.go
@@ -15,19 +15,20 @@ import (
 	"github.com/andreychh/tgen/model/pipeline/typed"
 )
 
-// Methods is the table of resolved methods, keyed by reference.
+// Methods is the table of what each method has of its own, keyed by reference.
+// Only a definition of method kind has a record here, so the table holds fewer
+// records than there are definitions.
 type Methods = pipeline.Table[model.Reference, Method]
 
 // Specification is the database after every method's return type is decoded
-// from its description prose into a type expression. The object, field,
-// discriminator, union, and variant tables and the release ride through from
-// the typed stage unchanged.
+// from its description prose into a type expression. The definition, field,
+// discriminator, and variant tables and the release ride through from the
+// typed stage unchanged.
 type Specification struct {
-	Objects        parsed.Objects
+	Definitions    parsed.Definitions
 	Methods        Methods
 	Fields         typed.Fields
 	Discriminators classified.Discriminators
-	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Release        parsed.Release
 }
@@ -43,20 +44,23 @@ func NewPass(spec typed.Specification) Pass {
 	return Pass{spec: spec}
 }
 
-// Specification returns the resolved specification, decoding every method's
-// return type from its description prose into a type expression. It fails when
-// any method's return type prose cannot be decoded.
+// Specification returns the resolved specification, decoding the return type of
+// every definition of method kind from its description prose into a type
+// expression. It fails when any method's return type prose cannot be decoded.
 func (p Pass) Specification() (Specification, error) {
-	methods, err := pipeline.NewMappedTable(p.spec.Methods, NewMethodMapping()).Apply()
+	definitions := pipeline.NewFilteredTable(
+		p.spec.Definitions,
+		parsed.NewKindFilter(model.DefinitionKindMethod),
+	).Apply()
+	methods, err := pipeline.NewMappedTable(definitions, NewMethodMapping()).Apply()
 	if err != nil {
-		return Specification{}, fmt.Errorf("resolving methods: %w", err)
+		return Specification{}, fmt.Errorf("resolving return types: %w", err)
 	}
 	return Specification{
-		Objects:        p.spec.Objects,
+		Definitions:    p.spec.Definitions,
 		Methods:        methods,
 		Fields:         p.spec.Fields,
 		Discriminators: p.spec.Discriminators,
-		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,
 		Release:        p.spec.Release,
 	}, nil

--- a/model/pipeline/separated/method.go
+++ b/model/pipeline/separated/method.go
@@ -7,22 +7,19 @@ import (
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline/flattened"
 	"github.com/andreychh/tgen/model/primitive"
-	"github.com/andreychh/tgen/model/prose"
 	"github.com/andreychh/tgen/model/result"
 	"github.com/andreychh/tgen/model/typeform"
 )
 
-// Method is the record of a documentation method whose return is split into
-// what the method signals: its reference, name, description, and result.
+// Method is what a method has of its own, with its return split into what the
+// method signals: a confirmation of success, or the value it carries.
 type Method struct {
-	Ref         model.Reference
-	Name        model.Name
-	Description prose.Passage
-	Result      result.Result
+	Ref    model.Reference
+	Result result.Result
 }
 
 // MethodMapping maps a flattened method into a separated one by deciding
-// whether its return type carries data or only reports success.
+// whether its return carries data or only reports success.
 type MethodMapping struct{}
 
 // NewMethodMapping constructs a MethodMapping.
@@ -33,10 +30,8 @@ func NewMethodMapping() MethodMapping {
 // Apply implements [pipeline.Mapping]. It never fails.
 func (m MethodMapping) Apply(method flattened.Method) (Method, error) {
 	return Method{
-		Ref:         method.Ref,
-		Name:        method.Name,
-		Description: method.Description,
-		Result:      m.classify(method.Type),
+		Ref:    method.Ref,
+		Result: m.classify(method.Type),
 	}, nil
 }
 

--- a/model/pipeline/separated/specification.go
+++ b/model/pipeline/separated/specification.go
@@ -15,18 +15,17 @@ import (
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 )
 
-// Methods is the table of separated methods, keyed by reference.
+// Methods is the table of what each method has of its own, keyed by reference.
 type Methods = pipeline.Table[model.Reference, Method]
 
 // Specification is the database after every method's return is split into what
-// the method signals. The object, field, discriminator, union, variant, and
-// alias tables and the release ride through from the flattened stage unchanged.
+// the method signals. The definition, field, discriminator, variant, and alias
+// tables and the release ride through from the flattened stage unchanged.
 type Specification struct {
-	Objects        parsed.Objects
+	Definitions    parsed.Definitions
 	Methods        Methods
 	Fields         flattened.Fields
 	Discriminators classified.Discriminators
-	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Aliases        flattened.Aliases
 	Release        parsed.Release
@@ -53,11 +52,10 @@ func (p Pass) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("separating methods: %w", err)
 	}
 	return Specification{
-		Objects:        p.spec.Objects,
+		Definitions:    p.spec.Definitions,
 		Methods:        methods,
 		Fields:         p.spec.Fields,
 		Discriminators: p.spec.Discriminators,
-		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,
 		Aliases:        p.spec.Aliases,
 		Release:        p.spec.Release,

--- a/model/pipeline/typed/specification.go
+++ b/model/pipeline/typed/specification.go
@@ -19,14 +19,12 @@ import (
 type Fields = pipeline.Table[model.FieldKey, Field]
 
 // Specification is the database after every field's type prose is resolved into
-// a type expression. The object, method, discriminator, union, and variant
-// tables and the release ride through from the unified stage unchanged.
+// a type expression. The definition, discriminator, and variant tables and the
+// release ride through from the unified stage unchanged.
 type Specification struct {
-	Objects        parsed.Objects
-	Methods        parsed.Methods
+	Definitions    parsed.Definitions
 	Fields         Fields
 	Discriminators classified.Discriminators
-	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Release        parsed.Release
 }
@@ -51,11 +49,9 @@ func (p Pass) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("typing fields: %w", err)
 	}
 	return Specification{
-		Objects:        p.spec.Objects,
-		Methods:        p.spec.Methods,
+		Definitions:    p.spec.Definitions,
 		Fields:         fields,
 		Discriminators: p.spec.Discriminators,
-		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,
 		Release:        p.spec.Release,
 	}, nil

--- a/model/pipeline/unified/specification.go
+++ b/model/pipeline/unified/specification.go
@@ -19,15 +19,13 @@ import (
 type Fields = pipeline.Table[model.FieldKey, Field]
 
 // Specification is the database after object fields and method parameters are
-// merged into a single table of fields. The object, method, discriminator,
-// union, and variant tables and the release ride through from the classified
-// stage unchanged.
+// merged into a single table of fields. The definition, discriminator, and
+// variant tables and the release ride through from the classified stage
+// unchanged.
 type Specification struct {
-	Objects        parsed.Objects
-	Methods        parsed.Methods
+	Definitions    parsed.Definitions
 	Fields         Fields
 	Discriminators classified.Discriminators
-	Unions         parsed.Unions
 	Variants       parsed.Variants
 	Release        parsed.Release
 }
@@ -60,11 +58,9 @@ func (p Pass) Specification() (Specification, error) {
 		return Specification{}, fmt.Errorf("merging fields and parameters: %w", err)
 	}
 	return Specification{
-		Objects:        p.spec.Objects,
-		Methods:        p.spec.Methods,
+		Definitions:    p.spec.Definitions,
 		Fields:         merged,
 		Discriminators: p.spec.Discriminators,
-		Unions:         p.spec.Unions,
 		Variants:       p.spec.Variants,
 		Release:        p.spec.Release,
 	}, nil


### PR DESCRIPTION
This PR replaces the per-kind `Objects`, `Methods`, and `Unions` tables with a single `Definitions` table carrying what every definition shares, leaving each kind only the columns that are its own. A reference now names at most one definition by construction, so `alreadyExists` is gone and a collision between kinds — which nothing checked before — is reported by the merge that builds the table.

Positions are assigned by `DefinitionTable` and `VariantTable` when a record is inserted rather than computed by the rules writing into them, since a position states where a record stands among its neighbours and only the table holding those neighbours knows them.

Closes #244