### PR TITLE
Add the `attached` pass marking file-carrying definitions

### DIFF
--- a/model/pipeline/attached/file.go
+++ b/model/pipeline/attached/file.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package attached
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+)
+
+// Kind tells apart the two ways a definition has to do with a file: KindFile
+// marks the type a file is sent as, which is one definition and no other;
+// KindCarrier marks a definition holding one somewhere inside, however deep.
+// A caller reads the kind to know whether a value hands over its file itself
+// or asks what it holds to hand over theirs.
+type Kind string
+
+const (
+	KindFile    Kind = "file"
+	KindCarrier Kind = "carrier"
+)
+
+// File is what one definition has to do with a file.
+type File struct {
+	Ref  model.Reference
+	Kind Kind
+}
+
+// FileTable is the spreading operator: it starts from the type a file is sent
+// as and marks everything the rules can reach from there.
+type FileTable struct {
+	seed  model.Reference
+	rules []Rule
+}
+
+// NewFileTable constructs a FileTable spreading from seed by the given rules.
+func NewFileTable(seed model.Reference, rules ...Rule) FileTable {
+	return FileTable{seed: seed, rules: rules}
+}
+
+// Table returns every definition that can carry a file, keyed by reference. The
+// spread repeats until a round marks nothing new, so a definition holding its
+// own kind — a rich block nesting rich blocks — settles instead of circling.
+func (t FileTable) Table() Files {
+	out := pipeline.NewMapTable[model.Reference, File]()
+	out.Insert(t.seed, File{Ref: t.seed, Kind: KindFile})
+	for t.spread(out) {
+	}
+	return out
+}
+
+// spread runs every rule once against out and reports whether the round marked
+// a definition out did not already hold.
+func (t FileTable) spread(out pipeline.MapTable[model.Reference, File]) bool {
+	grew := false
+	for _, rule := range t.rules {
+		for _, ref := range rule.Apply(out) {
+			if _, marked := out.Lookup(ref); marked {
+				continue
+			}
+			out.Insert(ref, File{Ref: ref, Kind: KindCarrier})
+			grew = true
+		}
+	}
+	return grew
+}

--- a/model/pipeline/attached/rule.go
+++ b/model/pipeline/attached/rule.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package attached
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/flattened"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/typeform"
+)
+
+// Rule reports which definitions one relation of the specification adds to
+// those already known to carry a file. A rule only reads the set it is given —
+// the table that owns the set decides what to do with the answer — and may name
+// a definition the set already holds.
+type Rule interface {
+	// Apply returns the definitions that carry a file because a definition in
+	// files does.
+	Apply(files Files) []model.Reference
+}
+
+// FieldRule is the [Rule] of ownership: a definition carries a file when a
+// field it owns is typed as something that does. Dimensionality does not
+// matter, since an array of carriers carries too.
+type FieldRule struct {
+	fields flattened.Fields
+}
+
+// NewFieldRule constructs a FieldRule over a table of fields.
+func NewFieldRule(fields flattened.Fields) FieldRule {
+	return FieldRule{fields: fields}
+}
+
+// Apply implements [Rule].
+func (r FieldRule) Apply(files Files) []model.Reference {
+	out := make([]model.Reference, 0)
+	for key, field := range r.fields.All() {
+		named, ok := field.Type.Atom().(typeform.Named)
+		if !ok {
+			continue
+		}
+		if _, carries := files.Lookup(named.Ref()); !carries {
+			continue
+		}
+		out = append(out, key.Owner)
+	}
+	return out
+}
+
+// VariantRule is the [Rule] of alternation: a union carries a file when one of
+// the definitions it is told apart into does. A union owns no field, so this is
+// the only way a file reaches it.
+type VariantRule struct {
+	variants parsed.Variants
+}
+
+// NewVariantRule constructs a VariantRule over a table of variants.
+func NewVariantRule(variants parsed.Variants) VariantRule {
+	return VariantRule{variants: variants}
+}
+
+// Apply implements [Rule].
+func (r VariantRule) Apply(files Files) []model.Reference {
+	out := make([]model.Reference, 0)
+	for key := range r.variants.All() {
+		if _, carries := files.Lookup(key.Ref); !carries {
+			continue
+		}
+		out = append(out, key.Owner)
+	}
+	return out
+}
+
+// AliasRule is the [Rule] of standing for: an alias carries a file when the
+// type it stands for does.
+type AliasRule struct {
+	aliases flattened.Aliases
+}
+
+// NewAliasRule constructs an AliasRule over a table of aliases.
+func NewAliasRule(aliases flattened.Aliases) AliasRule {
+	return AliasRule{aliases: aliases}
+}
+
+// Apply implements [Rule].
+func (r AliasRule) Apply(files Files) []model.Reference {
+	out := make([]model.Reference, 0)
+	for ref, alias := range r.aliases.All() {
+		named, ok := alias.Type.Atom().(typeform.Named)
+		if !ok {
+			continue
+		}
+		if _, carries := files.Lookup(named.Ref()); !carries {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out
+}

--- a/model/pipeline/attached/specification.go
+++ b/model/pipeline/attached/specification.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package attached marks every definition that can carry a file: the type a
+// file is sent as, and everything holding one however deep. A target reads the
+// mark to decide how a method sends its request, since a file travels as a
+// multipart part while everything else travels as JSON.
+package attached
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/classified"
+	"github.com/andreychh/tgen/model/pipeline/corrected"
+	"github.com/andreychh/tgen/model/pipeline/flattened"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+)
+
+// Files is the table of what each definition has to do with a file, keyed by
+// reference. A definition the table does not hold carries no file.
+type Files = pipeline.Table[model.Reference, File]
+
+// Specification is the database after every definition that can carry a file
+// is marked. The definition, method, field, discriminator, variant, and alias
+// tables and the release ride through from the flattened stage unchanged.
+type Specification struct {
+	Definitions    parsed.Definitions
+	Methods        flattened.Methods
+	Fields         flattened.Fields
+	Files          Files
+	Discriminators classified.Discriminators
+	Variants       parsed.Variants
+	Aliases        flattened.Aliases
+	Release        parsed.Release
+}
+
+// Pass is the attaching stage: it rewrites a flattened specification into an
+// attached one, spreading the mark of a file from the type it is sent as to
+// everything that can hold one. It reads the flat types a field and an alias
+// were reduced to, and nothing a later stage decides, so it stands here.
+type Pass struct {
+	spec flattened.Specification
+}
+
+// NewPass constructs a Pass over a flattened specification.
+func NewPass(spec flattened.Specification) Pass {
+	return Pass{spec: spec}
+}
+
+// Specification returns the attached specification, marking every definition
+// that can carry a file. It fails when the specification names no type a file
+// is sent as, which leaves the mark nothing to spread from and would quietly
+// report that no method sends a file at all.
+func (p Pass) Specification() (Specification, error) {
+	if _, found := p.spec.Definitions.Lookup(corrected.InputFileRef); !found {
+		return Specification{}, fmt.Errorf("%s names no definition", corrected.InputFileRef)
+	}
+	return Specification{
+		Definitions: p.spec.Definitions,
+		Methods:     p.spec.Methods,
+		Fields:      p.spec.Fields,
+		Files: NewFileTable(
+			corrected.InputFileRef,
+			NewFieldRule(p.spec.Fields),
+			NewVariantRule(p.spec.Variants),
+			NewAliasRule(p.spec.Aliases),
+		).Table(),
+		Discriminators: p.spec.Discriminators,
+		Variants:       p.spec.Variants,
+		Aliases:        p.spec.Aliases,
+		Release:        p.spec.Release,
+	}, nil
+}

--- a/model/pipeline/corrected/input_file.go
+++ b/model/pipeline/corrected/input_file.go
@@ -15,10 +15,15 @@ import (
 	"github.com/andreychh/tgen/model/typeexpr"
 )
 
+// InputFileRef is the reference of the InputFile union this stage introduces.
+// A later stage decides which definitions can carry a file, and it starts from
+// here: InputFile is the only type that is one, and the documentation never
+// names it, so nothing downstream can find it on its own.
+const InputFileRef = model.Reference("inputfile")
+
 const (
-	inputFileRef = model.Reference("inputfile")
-	fileIDRef    = model.Reference("fileid")
-	uploadRef    = model.Reference("upload")
+	fileIDRef = model.Reference("fileid")
+	uploadRef = model.Reference("upload")
 )
 
 // InputFile is a [Rule] that introduces the InputFile union — a file to
@@ -63,7 +68,7 @@ func (r InputFile) Apply(spec Specification) (Specification, error) {
 func (r InputFile) definitions(base parsed.Definitions) (parsed.Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
-		inputFileRef,
+		InputFileRef,
 		"InputFile",
 		model.DefinitionKindUnion,
 		prose.NewPassage(prose.NewParagraph(prose.NewText(
@@ -102,7 +107,7 @@ func (r InputFile) aliases() Aliases {
 // so it still needs its own design before it can join the union. It fails when
 // the union already lists FileId.
 func (r InputFile) variants(base parsed.Variants) (parsed.Variants, error) {
-	out := NewVariantTable(base, inputFileRef)
+	out := NewVariantTable(base, InputFileRef)
 	err := out.Insert(
 		fileIDRef,
 	)
@@ -119,7 +124,7 @@ type inputFileFilter struct{}
 // Apply implements [pipeline.Filter]. It reports whether definition belongs in
 // the filtered result: false when ref is inputfile.
 func (inputFileFilter) Apply(ref model.Reference, definition parsed.Definition) bool {
-	return ref != inputFileRef
+	return ref != InputFileRef
 }
 
 // inputFileMapping is a [pipeline.Mapping] that redirects a field that could
@@ -135,7 +140,7 @@ func (m inputFileMapping) Apply(field typed.Field) (typed.Field, error) {
 	return typed.Field{
 		Key:         field.Key,
 		Position:    field.Position,
-		Type:        typeexpr.NewNamed(inputFileRef),
+		Type:        typeexpr.NewNamed(InputFileRef),
 		Optionality: field.Optionality,
 		Description: field.Description,
 	}, nil
@@ -145,9 +150,9 @@ func (m inputFileMapping) Apply(field typed.Field) (typed.Field, error) {
 // String, or as a bare String field whose description links to the
 // sending-files guide.
 func (m inputFileMapping) matches(field typed.Field) bool {
-	return field.Type.Equals(typeexpr.NewNamed(inputFileRef)) ||
+	return field.Type.Equals(typeexpr.NewNamed(InputFileRef)) ||
 		field.Type.Equals(typeexpr.NewUnion(
-			typeexpr.NewNamed(inputFileRef),
+			typeexpr.NewNamed(InputFileRef),
 			typeexpr.NewPrimitive(primitive.String),
 		)) ||
 		field.Type.Equals(typeexpr.NewPrimitive(primitive.String)) &&

--- a/model/pipeline/separated/specification.go
+++ b/model/pipeline/separated/specification.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/attached"
 	"github.com/andreychh/tgen/model/pipeline/classified"
 	"github.com/andreychh/tgen/model/pipeline/flattened"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
@@ -19,27 +20,28 @@ import (
 type Methods = pipeline.Table[model.Reference, Method]
 
 // Specification is the database after every method's return is split into what
-// the method signals. The definition, field, discriminator, variant, and alias
-// tables and the release ride through from the flattened stage unchanged.
+// the method signals. The definition, field, discriminator, variant, alias, and
+// file tables and the release ride through from the attached stage unchanged.
 type Specification struct {
 	Definitions    parsed.Definitions
 	Methods        Methods
 	Fields         flattened.Fields
+	Files          attached.Files
 	Discriminators classified.Discriminators
 	Variants       parsed.Variants
 	Aliases        flattened.Aliases
 	Release        parsed.Release
 }
 
-// Pass is the separation stage: it rewrites a flattened specification into a
+// Pass is the separation stage: it rewrites an attached specification into a
 // separated one, deciding for every method whether its return carries data or
 // only reports success.
 type Pass struct {
-	spec flattened.Specification
+	spec attached.Specification
 }
 
-// NewPass constructs a Pass over a flattened specification.
-func NewPass(spec flattened.Specification) Pass {
+// NewPass constructs a Pass over an attached specification.
+func NewPass(spec attached.Specification) Pass {
 	return Pass{spec: spec}
 }
 
@@ -55,6 +57,7 @@ func (p Pass) Specification() (Specification, error) {
 		Definitions:    p.spec.Definitions,
 		Methods:        methods,
 		Fields:         p.spec.Fields,
+		Files:          p.spec.Files,
 		Discriminators: p.spec.Discriminators,
 		Variants:       p.spec.Variants,
 		Aliases:        p.spec.Aliases,


### PR DESCRIPTION
This PR adds `attached`, a pipeline stage that marks every definition reachable from `InputFile` through a field, a union variant, or an alias, and places it between `flattened` and `separated`.

The table records whether a definition is the file type itself or merely holds one, so a target can tell `place` from `resolve` without reaching back into `corrected` for the `InputFile` reference.

Closes #246