### PR TITLE
Add `model/ir/v2` and the `golangv2` target over the nanopass pipeline

### DIFF
--- a/model/ir/v2/alias.go
+++ b/model/ir/v2/alias.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/typebound"
+)
+
+// Alias is the record of a name tgen gives a type the documentation leaves
+// unnamed, joined with the type that name stands for.
+type Alias struct {
+	Ref         model.Reference
+	Name        model.Name
+	Type        typebound.Type
+	Description prose.Passage
+}
+
+func (Alias) isDefinition() {}

--- a/model/ir/v2/definition.go
+++ b/model/ir/v2/definition.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+// Definition represents one thing the specification names, joined with what it
+// owns. A target walks the sum rather than a sequence per kind, because the
+// page numbers its headings in a single run: an object, a union and a method
+// stand beside each other there, and only a sum can hold that order. The
+// concrete variants are [Object], [DiscriminatedObject], [Union],
+// [DiscriminatedUnion], [Alias] and [Method].
+//
+//sumtype:decl
+type Definition interface {
+	isDefinition()
+}

--- a/model/ir/v2/discriminated_object.go
+++ b/model/ir/v2/discriminated_object.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// DiscriminatedObject is the record of an object a union tells apart by a
+// discriminator, joined with the fields it owns and the fixed value it is told
+// apart by. It stands beside [Object], not on top of it: the two partition the
+// objects the documentation names, and no object is both. Files narrows Fields
+// to those reaching a file, and is empty for an object holding none. Rewrites
+// reports the same as it does for [Object].
+type DiscriminatedObject struct {
+	Ref           model.Reference
+	Name          model.Name
+	Description   prose.Passage
+	Fields        []Field
+	Files         []FileField
+	Rewrites      bool
+	Discriminator Discriminator
+}
+
+func (DiscriminatedObject) isDefinition() {}
+
+// Discriminator is the field an object is told apart by and the fixed value it
+// holds there. The pipeline moves that field out of the field table, so this
+// value is the only place it survives.
+type Discriminator struct {
+	Key   model.Key
+	Value model.DiscriminatorValue
+}

--- a/model/ir/v2/fields.go
+++ b/model/ir/v2/fields.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/flattened"
+	"github.com/andreychh/tgen/model/pipeline/separated"
+	"github.com/andreychh/tgen/model/typeform"
+)
+
+// Fields is the ordered view of the fields one definition owns, each with its
+// type bound to the definition it names.
+type Fields struct {
+	db    separated.Specification
+	owner model.Reference
+}
+
+// NewFields constructs a Fields over the fields owner holds in the database.
+func NewFields(db separated.Specification, owner model.Reference) Fields {
+	return Fields{db: db, owner: owner}
+}
+
+// Value returns the fields of the owner, ordered by the position their source
+// gave them. It fails when a field's type names no definition.
+func (f Fields) Value() ([]Field, error) {
+	records := f.records()
+	out := make([]Field, 0, len(records))
+	for _, record := range records {
+		field, err := f.field(record)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, field)
+	}
+	return out, nil
+}
+
+// Files returns the fields of the owner that reach a file, ordered by the
+// position their source gave them, each with the way it reaches one. A field
+// typed as a built-in reaches nothing, since only a definition is ever marked.
+// It fails when a field's type names no definition.
+func (f Fields) Files() ([]FileField, error) {
+	out := make([]FileField, 0)
+	for _, record := range f.records() {
+		named, ok := record.Type.Atom().(typeform.Named)
+		if !ok {
+			continue
+		}
+		mark, reaches := f.db.Files.Lookup(named.Ref())
+		if !reaches {
+			continue
+		}
+		field, err := f.field(record)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, FileField{Field: field, Kind: mark.Kind})
+	}
+	return out, nil
+}
+
+// field returns the record read as a field, with its type bound to the
+// definition it names. It fails when that type names no definition.
+func (f Fields) field(record flattened.Field) (Field, error) {
+	typ, err := NewResolution(f.db, record.Type).Value()
+	if err != nil {
+		return Field{}, fmt.Errorf("binding the type of %s.%s: %w", f.owner, record.Key, err)
+	}
+	return Field{
+		Key:         record.Key,
+		Type:        typ,
+		Optionality: record.Optionality,
+		Description: record.Description,
+	}, nil
+}
+
+// records returns the raw field records of the owner, ordered by position.
+func (f Fields) records() []flattened.Field {
+	out := make([]flattened.Field, 0)
+	for key, record := range f.db.Fields.All() {
+		if key.Owner != f.owner {
+			continue
+		}
+		out = append(out, record)
+	}
+	slices.SortFunc(out, func(a, b flattened.Field) int {
+		return cmp.Compare(a.Position, b.Position)
+	})
+	return out
+}

--- a/model/ir/v2/file_field.go
+++ b/model/ir/v2/file_field.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"github.com/andreychh/tgen/model"
+)
+
+// FileField is a field that reaches a file, joined with the way it reaches one.
+// It is a field of its owner narrowed to one concern, so it carries everything
+// [Field] carries and never stands on its own.
+type FileField struct {
+	Field
+
+	Kind model.FileKind
+}

--- a/model/ir/v2/method.go
+++ b/model/ir/v2/method.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/separated"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/result"
+)
+
+// Method is the record of a documented method, joined with the parameters it
+// takes and the result it returns. Name is the name the endpoint is called by,
+// which is also the name a target derives its identifier from. Files narrows
+// Params to those reaching a file, and is empty for a method sending none.
+type Method struct {
+	Ref         model.Reference
+	Name        model.Name
+	Description prose.Passage
+	Params      []Field
+	Files       []FileField
+	Result      Result
+}
+
+func (Method) isDefinition() {}
+
+// Returned is the view of what one method returns, with the type it carries
+// bound to the definition that type names.
+type Returned struct {
+	db    separated.Specification
+	inner result.Result
+}
+
+// NewReturned constructs a Returned over the result a method was separated
+// into.
+func NewReturned(db separated.Specification, inner result.Result) Returned {
+	return Returned{db: db, inner: inner}
+}
+
+// Value returns the result with its carried type bound. It fails when that type
+// names no definition.
+func (r Returned) Value() (Result, error) {
+	switch inner := r.inner.(type) {
+	case result.Confirmation:
+		return NewConfirmation(), nil
+	case result.Value:
+		typ, err := NewResolution(r.db, inner.Type()).Value()
+		if err != nil {
+			return nil, fmt.Errorf("binding the returned type: %w", err)
+		}
+		return NewValue(typ), nil
+	default:
+		return nil, fmt.Errorf("unknown result %T", inner)
+	}
+}

--- a/model/ir/v2/object.go
+++ b/model/ir/v2/object.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/typebound"
+)
+
+// Object is the record of a documented object, joined with the fields it owns.
+// Files narrows Fields to those reaching a file, and is empty for an object
+// holding none. Rewrites reports that a union reaching a file admits the object,
+// which obliges it to rewrite itself into JSON even when it holds no file of its
+// own: a union carries a file as soon as one variant does, and every target
+// reaches the rest of them through the same rewrite.
+type Object struct {
+	Ref         model.Reference
+	Name        model.Name
+	Description prose.Passage
+	Fields      []Field
+	Files       []FileField
+	Rewrites    bool
+}
+
+func (Object) isDefinition() {}
+
+// Field is the record of a field an object owns or a parameter a method takes,
+// with its type bound to the definition it names.
+type Field struct {
+	Key         model.Key
+	Type        typebound.Type
+	Optionality model.Optionality
+	Description prose.Phrase
+}

--- a/model/ir/v2/ordered.go
+++ b/model/ir/v2/ordered.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+)
+
+// Ordered is the definitions table read as a sequence: what the table holds
+// keyed by reference, given back in the order its source put it in.
+type Ordered struct {
+	definitions parsed.Definitions
+}
+
+// NewOrdered constructs an Ordered over a definitions table.
+func NewOrdered(definitions parsed.Definitions) Ordered {
+	return Ordered{definitions: definitions}
+}
+
+// Value returns every definition the table holds, ordered by the position its
+// source gave it. A table iterates in no order, so ordering here is what makes
+// generated output the same on every run.
+func (o Ordered) Value() []parsed.Definition {
+	out := make([]parsed.Definition, 0, o.definitions.Count())
+	for _, definition := range o.definitions.All() {
+		out = append(out, definition)
+	}
+	slices.SortFunc(out, func(a, b parsed.Definition) int {
+		return cmp.Compare(a.Position, b.Position)
+	})
+	return out
+}

--- a/model/ir/v2/reading.go
+++ b/model/ir/v2/reading.go
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/separated"
+)
+
+// Reading is one definition read as the record a target renders: it joins the
+// definition with what the tables hold for it, and gives back the record of the
+// kind the definition is of.
+type Reading struct {
+	db         separated.Specification
+	definition parsed.Definition
+}
+
+// NewReading constructs a Reading of one definition against the database
+// holding what that definition owns.
+func NewReading(db separated.Specification, definition parsed.Definition) Reading {
+	return Reading{db: db, definition: definition}
+}
+
+// Value returns the definition read as the record of its kind. An object is
+// read as the variant its discriminator makes it, since a union telling it apart
+// changes what a target writes for it. It fails when the join fails, and when no
+// record stands for the kind the definition is of.
+func (r Reading) Value() (Definition, error) {
+	switch r.definition.Kind {
+	case model.DefinitionKindObject:
+		if _, discriminated := r.db.Discriminators.Lookup(r.definition.Ref); discriminated {
+			return r.discriminatedObject()
+		}
+		return r.object()
+	case model.DefinitionKindMethod:
+		return r.method()
+	case model.DefinitionKindAlias:
+		return r.alias()
+	case model.DefinitionKindUnion:
+		return r.union()
+	default:
+		return nil, fmt.Errorf(
+			"%s names a definition of unknown kind %q",
+			r.definition.Ref,
+			r.definition.Kind,
+		)
+	}
+}
+
+// object returns the definition joined with the fields it owns.
+func (r Reading) object() (Object, error) {
+	fields, err := NewFields(r.db, r.definition.Ref).Value()
+	if err != nil {
+		return Object{}, fmt.Errorf("joining object %s: %w", r.definition.Ref, err)
+	}
+	files, err := NewFields(r.db, r.definition.Ref).Files()
+	if err != nil {
+		return Object{}, fmt.Errorf("joining object %s: %w", r.definition.Ref, err)
+	}
+	return Object{
+		Ref:         r.definition.Ref,
+		Name:        r.definition.Name,
+		Description: r.definition.Description,
+		Fields:      fields,
+		Files:       files,
+		Rewrites:    r.rewrites(),
+	}, nil
+}
+
+// rewrites reports whether a union reaching a file admits the definition, which
+// obliges it to rewrite itself into JSON however little it has to hand over.
+func (r Reading) rewrites() bool {
+	for key := range r.db.Variants.All() {
+		if key.Ref != r.definition.Ref {
+			continue
+		}
+		mark, reaches := r.db.Files.Lookup(key.Owner)
+		if reaches && mark.Kind == model.FileKindCarrier {
+			return true
+		}
+	}
+	return false
+}
+
+// discriminatedObject returns the definition joined with the fields it owns and
+// the fixed value it is told apart by. It fails when no union tells it apart.
+func (r Reading) discriminatedObject() (DiscriminatedObject, error) {
+	discriminator, discriminated := r.db.Discriminators.Lookup(r.definition.Ref)
+	if !discriminated {
+		return DiscriminatedObject{}, fmt.Errorf(
+			"object %s is told apart by nothing",
+			r.definition.Ref,
+		)
+	}
+	fields, err := NewFields(r.db, r.definition.Ref).Value()
+	if err != nil {
+		return DiscriminatedObject{}, fmt.Errorf(
+			"joining discriminated object %s: %w",
+			r.definition.Ref,
+			err,
+		)
+	}
+	files, err := NewFields(r.db, r.definition.Ref).Files()
+	if err != nil {
+		return DiscriminatedObject{}, fmt.Errorf(
+			"joining discriminated object %s: %w",
+			r.definition.Ref,
+			err,
+		)
+	}
+	return DiscriminatedObject{
+		Ref:         r.definition.Ref,
+		Name:        r.definition.Name,
+		Description: r.definition.Description,
+		Fields:      fields,
+		Files:       files,
+		Rewrites:    r.rewrites(),
+		Discriminator: Discriminator{
+			Key:   discriminator.Key,
+			Value: discriminator.Value,
+		},
+	}, nil
+}
+
+// union returns the definition joined with the variants it stands for: told
+// apart by a key when one key tells every variant apart with a value of its own,
+// and told apart by nothing otherwise, since then only a target knows how. It
+// fails when a variant names no definition.
+func (r Reading) union() (Definition, error) {
+	mark, reaches := r.db.Files.Lookup(r.definition.Ref)
+	carrier := reaches && mark.Kind == model.FileKindCarrier
+	key, discriminated, err := NewVariants(r.db, r.definition.Ref).Discriminated()
+	if err != nil {
+		return nil, fmt.Errorf("joining union %s: %w", r.definition.Ref, err)
+	}
+	if len(discriminated) > 0 {
+		return DiscriminatedUnion{
+			Ref:         r.definition.Ref,
+			Name:        r.definition.Name,
+			Description: r.definition.Description,
+			Key:         key,
+			Variants:    discriminated,
+			Carrier:     carrier,
+		}, nil
+	}
+	variants, err := NewVariants(r.db, r.definition.Ref).Value()
+	if err != nil {
+		return nil, fmt.Errorf("joining union %s: %w", r.definition.Ref, err)
+	}
+	return Union{
+		Ref:         r.definition.Ref,
+		Name:        r.definition.Name,
+		Description: r.definition.Description,
+		Variants:    variants,
+		Carrier:     carrier,
+	}, nil
+}
+
+// method returns the definition joined with the parameters it takes and the
+// result it returns. It fails when the pipeline separated it into no result.
+func (r Reading) method() (Method, error) {
+	record, found := r.db.Methods.Lookup(r.definition.Ref)
+	if !found {
+		return Method{}, fmt.Errorf("method %s returns nothing", r.definition.Ref)
+	}
+	params, err := NewFields(r.db, r.definition.Ref).Value()
+	if err != nil {
+		return Method{}, fmt.Errorf("joining method %s: %w", r.definition.Ref, err)
+	}
+	files, err := NewFields(r.db, r.definition.Ref).Files()
+	if err != nil {
+		return Method{}, fmt.Errorf("joining method %s: %w", r.definition.Ref, err)
+	}
+	res, err := NewReturned(r.db, record.Result).Value()
+	if err != nil {
+		return Method{}, fmt.Errorf("joining method %s: %w", r.definition.Ref, err)
+	}
+	return Method{
+		Ref:         r.definition.Ref,
+		Name:        r.definition.Name,
+		Description: r.definition.Description,
+		Params:      params,
+		Files:       files,
+		Result:      res,
+	}, nil
+}
+
+// alias returns the definition joined with the type it stands for. It fails when
+// it stands for nothing.
+func (r Reading) alias() (Alias, error) {
+	record, found := r.db.Aliases.Lookup(r.definition.Ref)
+	if !found {
+		return Alias{}, fmt.Errorf("alias %s stands for nothing", r.definition.Ref)
+	}
+	typ, err := NewResolution(r.db, record.Type).Value()
+	if err != nil {
+		return Alias{}, fmt.Errorf("resolving alias %s: %w", r.definition.Ref, err)
+	}
+	return Alias{
+		Ref:         r.definition.Ref,
+		Name:        r.definition.Name,
+		Type:        typ,
+		Description: r.definition.Description,
+	}, nil
+}

--- a/model/ir/v2/resolution.go
+++ b/model/ir/v2/resolution.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model/typebound"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/separated"
+	"github.com/andreychh/tgen/model/typeform"
+)
+
+// Resolution is the join of a flat type with the tables naming its atom: it
+// replaces the reference the atom addresses with the definition it names, and
+// an alias with the type it stands for.
+type Resolution struct {
+	db  separated.Specification
+	typ typeform.Type
+}
+
+// NewResolution constructs a Resolution of a flat type against the database
+// naming its atom.
+func NewResolution(db separated.Specification, typ typeform.Type) Resolution {
+	return Resolution{db: db, typ: typ}
+}
+
+// Value returns the type with its atom resolved. It fails when the atom names
+// no definition, names a method, or names an alias the aliases table does not
+// hold.
+func (r Resolution) Value() (typebound.Type, error) {
+	switch atom := r.typ.Atom().(type) {
+	case typeform.Primitive:
+		return typebound.NewType(typebound.NewPrimitive(atom.Kind()), r.typ.Dimensionality()), nil
+	case typeform.Named:
+		resolved, err := r.named(atom.Ref())
+		if err != nil {
+			return typebound.Type{}, err
+		}
+		return typebound.NewType(resolved, r.typ.Dimensionality()), nil
+	default:
+		return typebound.Type{}, fmt.Errorf("resolving type atom: unexpected atom %T", atom)
+	}
+}
+
+// named returns the atom naming the definition ref addresses.
+func (r Resolution) named(ref model.Reference) (typebound.Atom, error) {
+	definition, found := r.db.Definitions.Lookup(ref)
+	if !found {
+		return nil, fmt.Errorf("%s names no definition", ref)
+	}
+	switch definition.Kind {
+	case model.DefinitionKindObject:
+		return typebound.NewObject(definition.Name), nil
+	case model.DefinitionKindUnion:
+		return typebound.NewUnion(definition.Name), nil
+	case model.DefinitionKindAlias:
+		return r.alias(ref, definition.Name)
+	case model.DefinitionKindMethod:
+		return nil, fmt.Errorf("%s names a method, which is not a type", ref)
+	default:
+		return nil, fmt.Errorf("%s names a definition of unknown kind %q", ref, definition.Kind)
+	}
+}
+
+// alias returns the atom naming the alias ref addresses, resolving the type it
+// stands for.
+func (r Resolution) alias(ref model.Reference, name model.Name) (typebound.Atom, error) {
+	alias, found := r.db.Aliases.Lookup(ref)
+	if !found {
+		return nil, fmt.Errorf("alias %s stands for nothing", ref)
+	}
+	under, err := NewResolution(r.db, alias.Type).Value()
+	if err != nil {
+		return nil, fmt.Errorf("resolving what alias %s stands for: %w", ref, err)
+	}
+	return typebound.NewAlias(name, under), nil
+}

--- a/model/ir/v2/result.go
+++ b/model/ir/v2/result.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"github.com/andreychh/tgen/model/typebound"
+)
+
+// Result represents what a method returns, with the type it carries bound to
+// the definition it names. The split between signalling and carrying is decided
+// in the pipeline; only the type is joined here. The concrete variants are
+// [Confirmation] and [Value].
+//
+//sumtype:decl
+type Result interface {
+	isResult()
+}
+
+// Confirmation represents a method result that only signals success.
+type Confirmation struct{}
+
+// NewConfirmation constructs a Confirmation.
+func NewConfirmation() Confirmation {
+	return Confirmation{}
+}
+
+func (Confirmation) isResult() {}
+
+// Value represents a method result that carries the resolved type it returns.
+type Value struct {
+	typ typebound.Type
+}
+
+// NewValue constructs a Value from the resolved type a method returns.
+func NewValue(typ typebound.Type) Value {
+	return Value{typ: typ}
+}
+
+// Type returns the bound type the Value carries.
+func (v Value) Type() typebound.Type {
+	return v.typ
+}
+
+func (Value) isResult() {}

--- a/model/ir/v2/specification.go
+++ b/model/ir/v2/specification.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package ir reads the normalized tables of the last pipeline stage as the
+// records a target renders: it joins a definition with what it owns, binds
+// every type to the definition it names, and puts both in the order their
+// source gave them. It is the pipeline's exit — nothing rewrites the
+// specification after it, and no target reaches past it to a table.
+//
+// Records are read as one sequence rather than one per kind. The page numbers
+// its headings in a single run, so an object, a union and a method stand beside
+// each other in it, and a target walking the sequence writes its file the way
+// the page reads. A definition tgen introduces has no place on the page and
+// follows every definition that has one.
+package ir
+
+import (
+	"github.com/andreychh/tgen/model/pipeline/separated"
+)
+
+// Specification represents the pipeline's database read as records to render.
+type Specification struct {
+	db separated.Specification
+}
+
+// NewSpecification constructs a Specification over a separated specification.
+func NewSpecification(db separated.Specification) Specification {
+	return Specification{db: db}
+}
+
+// Definitions returns every definition the specification names, each joined
+// with what it owns, ordered by the position its source gave it. It fails when
+// a definition cannot be read as the record of its kind.
+func (s Specification) Definitions() ([]Definition, error) {
+	out := make([]Definition, 0)
+	for _, definition := range NewOrdered(s.db.Definitions).Value() {
+		record, err := NewReading(s.db, definition).Value()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, record)
+	}
+	return out, nil
+}

--- a/model/ir/v2/union.go
+++ b/model/ir/v2/union.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// DiscriminatedUnion is the record of a union one key tells every variant of
+// apart, joined with that key and the variants it stands for. It stands beside
+// [Union], not on top of it: the two partition the unions the specification
+// names, and no union is both. Carrier reports that a file is reached through
+// the union, which every variant answers for by rewriting itself into JSON —
+// something a target has to say where it declares what the union accepts.
+type DiscriminatedUnion struct {
+	Ref         model.Reference
+	Name        model.Name
+	Description prose.Passage
+	Key         model.Key
+	Variants    []DiscriminatedVariant
+	Carrier     bool
+}
+
+func (DiscriminatedUnion) isDefinition() {}
+
+// DiscriminatedVariant is the record of one variant of a discriminated union:
+// the name of the type it stands for and the value it is told apart by. The
+// value is unique among the variants of its union — that is what made the union
+// discriminated.
+type DiscriminatedVariant struct {
+	Name  model.Name
+	Value model.DiscriminatorValue
+}
+
+// Union is the record of a union no key tells the variants of apart, joined with
+// the variants it stands for. Carrier reports the same as it does for
+// [DiscriminatedUnion]. The tables say which types the union accepts and nothing
+// about how to tell them apart, because nothing in the documentation does: one
+// union is told apart by the shape of the JSON, another by trying its variants
+// in turn, a third is only ever sent and never read. A target writes that by
+// hand.
+type Union struct {
+	Ref         model.Reference
+	Name        model.Name
+	Description prose.Passage
+	Variants    []Variant
+	Carrier     bool
+}
+
+func (Union) isDefinition() {}
+
+// Variant is the record of one variant of a union: the name of the type it
+// stands for.
+type Variant struct {
+	Name model.Name
+}

--- a/model/ir/v2/variants.go
+++ b/model/ir/v2/variants.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package ir
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/separated"
+)
+
+// Variants is the ordered view of the variants one union stands for, each named
+// by the definition it addresses.
+type Variants struct {
+	db    separated.Specification
+	owner model.Reference
+}
+
+// NewVariants constructs a Variants over the variants owner lists in the
+// database.
+func NewVariants(db separated.Specification, owner model.Reference) Variants {
+	return Variants{db: db, owner: owner}
+}
+
+// Value returns the variants of the union, ordered by the position their source
+// gave them. It fails when a variant names no definition.
+func (v Variants) Value() ([]Variant, error) {
+	records := v.records()
+	out := make([]Variant, 0, len(records))
+	for _, record := range records {
+		definition, found := v.db.Definitions.Lookup(record.Ref)
+		if !found {
+			return nil, fmt.Errorf("variant %s names no definition", record.Ref)
+		}
+		out = append(out, Variant{Name: definition.Name})
+	}
+	return out, nil
+}
+
+// Discriminated returns the key the variants of the union are marked under and
+// each variant with the value it is marked with, ordered by the position their
+// source gave them. It returns no key and no variant when one of them is marked
+// with nothing, when two are marked under different keys, or when two are marked
+// with the same value: none of the three tells the variants apart, so the key
+// means nothing and the union is read as a [Union]. It fails when a variant
+// names no definition.
+func (v Variants) Discriminated() (model.Key, []DiscriminatedVariant, error) {
+	key := model.Key("")
+	out := make([]DiscriminatedVariant, 0)
+	for at, record := range v.records() {
+		mark, marked := v.db.Discriminators.Lookup(record.Ref)
+		if !marked || (at > 0 && mark.Key != key) || holds(out, mark.Value) {
+			return "", nil, nil
+		}
+		definition, found := v.db.Definitions.Lookup(record.Ref)
+		if !found {
+			return "", nil, fmt.Errorf("variant %s names no definition", record.Ref)
+		}
+		key = mark.Key
+		out = append(out, DiscriminatedVariant{Name: definition.Name, Value: mark.Value})
+	}
+	return key, out, nil
+}
+
+// records returns the raw variant records of the union, ordered by position.
+func (v Variants) records() []parsed.Variant {
+	out := make([]parsed.Variant, 0)
+	for key, record := range v.db.Variants.All() {
+		if key.Owner != v.owner {
+			continue
+		}
+		out = append(out, record)
+	}
+	slices.SortFunc(out, func(a, b parsed.Variant) int {
+		return cmp.Compare(a.Position, b.Position)
+	})
+	return out
+}
+
+// holds reports whether value already tells one of the variants apart, which no
+// second variant of the same union may repeat.
+func holds(variants []DiscriminatedVariant, value model.DiscriminatorValue) bool {
+	return slices.ContainsFunc(variants, func(variant DiscriminatedVariant) bool {
+		return variant.Value == value
+	})
+}

--- a/model/model.go
+++ b/model/model.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // Package model defines the foundational value types shared across all layers
-// of the tgen pipeline: Name, Type, Description, Key, and their companions.
+// of the tgen pipeline: Name, Reference, Key, Position, and their companions.
 package model
 
 import "time"
@@ -22,6 +22,21 @@ const (
 	DefinitionKindMethod DefinitionKind = "method"
 	DefinitionKindUnion  DefinitionKind = "union"
 	DefinitionKindAlias  DefinitionKind = "alias"
+)
+
+// FileKind classifies what a reference has to do with a file, telling a target
+// whether the value hands its file over itself or asks what it holds to hand
+// over theirs. A reference classified by nothing reaches no file at all, which
+// is most of them, so the kind is carried only where it applies.
+type FileKind string
+
+const (
+	// FileKindFile marks the type a file is sent as, which is one definition and
+	// no other.
+	FileKindFile FileKind = "file"
+	// FileKindCarrier marks a definition holding a file somewhere inside, however
+	// deep.
+	FileKindCarrier FileKind = "carrier"
 )
 
 type Optionality bool

--- a/model/pipeline/attached/file.go
+++ b/model/pipeline/attached/file.go
@@ -8,22 +8,11 @@ import (
 	"github.com/andreychh/tgen/model/pipeline"
 )
 
-// Kind tells apart the two ways a definition has to do with a file: KindFile
-// marks the type a file is sent as, which is one definition and no other;
-// KindCarrier marks a definition holding one somewhere inside, however deep.
-// A caller reads the kind to know whether a value hands over its file itself
-// or asks what it holds to hand over theirs.
-type Kind string
-
-const (
-	KindFile    Kind = "file"
-	KindCarrier Kind = "carrier"
-)
-
-// File is what one definition has to do with a file.
+// File is what one definition has to do with a file, classified by
+// [model.FileKind].
 type File struct {
 	Ref  model.Reference
-	Kind Kind
+	Kind model.FileKind
 }
 
 // FileTable is the spreading operator: it starts from the type a file is sent
@@ -43,7 +32,7 @@ func NewFileTable(seed model.Reference, rules ...Rule) FileTable {
 // own kind — a rich block nesting rich blocks — settles instead of circling.
 func (t FileTable) Table() Files {
 	out := pipeline.NewMapTable[model.Reference, File]()
-	out.Insert(t.seed, File{Ref: t.seed, Kind: KindFile})
+	out.Insert(t.seed, File{Ref: t.seed, Kind: model.FileKindFile})
 	for t.spread(out) {
 	}
 	return out
@@ -58,7 +47,7 @@ func (t FileTable) spread(out pipeline.MapTable[model.Reference, File]) bool {
 			if _, marked := out.Lookup(ref); marked {
 				continue
 			}
-			out.Insert(ref, File{Ref: ref, Kind: KindCarrier})
+			out.Insert(ref, File{Ref: ref, Kind: model.FileKindCarrier})
 			grew = true
 		}
 	}

--- a/model/pipeline/corrected/input_file.go
+++ b/model/pipeline/corrected/input_file.go
@@ -63,8 +63,11 @@ func (r InputFile) Apply(spec Specification) (Specification, error) {
 }
 
 // definitions returns base holding what InputFile names too: the union itself,
-// taking the place of the documented object base no longer holds, and the file
-// id alias its variant stands for. It fails when either reference is taken.
+// taking the place of the documented object base no longer holds, the file id
+// alias one variant stands for, and the upload object the other is. The upload
+// object owns no field — what it holds, the bytes to send and the name to send
+// them under, has no shape shared across targets, so each target spells it
+// itself. It fails when any of the three references is taken.
 func (r InputFile) definitions(base parsed.Definitions) (parsed.Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
@@ -91,6 +94,19 @@ func (r InputFile) definitions(base parsed.Definitions) (parsed.Definitions, err
 	if err != nil {
 		return nil, fmt.Errorf("naming the file id alias: %w", err)
 	}
+	err = out.Insert(
+		uploadRef,
+		"Upload",
+		model.DefinitionKindObject,
+		prose.NewPassage(prose.NewParagraph(prose.NewText(
+			"Upload represents a file sent with the request, carrying the bytes to send "+
+				"and the name to send them under.",
+			prose.StylePlain,
+		))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("naming the upload object: %w", err)
+	}
 	return out, nil
 }
 
@@ -102,14 +118,14 @@ func (r InputFile) aliases() Aliases {
 	return out
 }
 
-// variants returns base listing InputFile's variants, which is FileId alone:
-// the upload variant holds a Go io.Reader with no shape shared across targets,
-// so it still needs its own design before it can join the union. It fails when
-// the union already lists FileId.
+// variants returns base listing InputFile's variants: a file Telegram already
+// holds, named by its id, and one uploaded with the request. It fails when the
+// union already lists either.
 func (r InputFile) variants(base parsed.Variants) (parsed.Variants, error) {
 	out := NewVariantTable(base, InputFileRef)
 	err := out.Insert(
 		fileIDRef,
+		uploadRef,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing input file variants: %w", err)

--- a/model/pipeline/parsed/field.go
+++ b/model/pipeline/parsed/field.go
@@ -16,8 +16,10 @@ import (
 
 // Field is the decoded record of one object field: its key, its position
 // among the object's other fields, and the verbatim prose of its type and
-// description. Resolving the type and lifting optionality are left for later
-// passes.
+// description. The description is never empty: the documentation describes
+// every field it lists, and a row that broke that would leave a name in the
+// generated code with nothing said about it. Resolving the type and lifting
+// optionality are left for later passes.
 type Field struct {
 	Key         model.Key
 	Position    model.Position
@@ -39,7 +41,8 @@ func NewFieldRow(at int, tr *goquery.Selection) FieldRow {
 
 // Record returns the field decoded from the row: its key, its position, and
 // the prose of its type and description. It fails when the key, type, or
-// description is malformed.
+// description is malformed, and when the row describes the field with
+// nothing.
 func (r FieldRow) Record() (Field, error) {
 	key, err := NewKey(r.cell(0)).Value()
 	if err != nil {
@@ -52,6 +55,9 @@ func (r FieldRow) Record() (Field, error) {
 	description, err := prose.NewPhrase(r.cell(2).Contents()).Value()
 	if err != nil {
 		return Field{}, fmt.Errorf("parsing field description: %w", err)
+	}
+	if len(description.Inlines()) == 0 {
+		return Field{}, fmt.Errorf("field %q is described by nothing", key)
 	}
 	return Field{
 		Key:         key,

--- a/model/pipeline/parsed/param.go
+++ b/model/pipeline/parsed/param.go
@@ -16,8 +16,9 @@ import (
 
 // Param is the decoded record of one method parameter: its key, its position
 // among the method's other parameters, and the verbatim prose of its type,
-// requiredness, and description. Lifting optionality is left for a later
-// pass, as with object fields.
+// requiredness, and description. The description is never empty, as with an
+// object field. Lifting optionality is left for a later pass, as with object
+// fields.
 type Param struct {
 	Key         model.Key
 	Position    model.Position
@@ -40,7 +41,8 @@ func NewParamRow(at int, tr *goquery.Selection) ParamRow {
 
 // Record returns the parameter decoded from the row: its key, its position,
 // and the prose of its type, requiredness, and description. It fails when the
-// key, type, requiredness, or description is malformed.
+// key, type, requiredness, or description is malformed, and when the row
+// describes the parameter with nothing.
 func (r ParamRow) Record() (Param, error) {
 	key, err := NewKey(r.cell(0)).Value()
 	if err != nil {
@@ -57,6 +59,9 @@ func (r ParamRow) Record() (Param, error) {
 	description, err := prose.NewPhrase(r.cell(3).Contents()).Value()
 	if err != nil {
 		return Param{}, fmt.Errorf("parsing parameter description: %w", err)
+	}
+	if len(description.Inlines()) == 0 {
+		return Param{}, fmt.Errorf("parameter %q is described by nothing", key)
 	}
 	return Param{
 		Key:         key,

--- a/model/typebound/atom.go
+++ b/model/typebound/atom.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package typebound
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/primitive"
+)
+
+// Atom represents what a type ultimately holds, with whatever it names already
+// resolved. What a typeform atom leaves to a reference — the name of a
+// definition and the shape a target must render it as — the variants carry
+// themselves. The concrete variants are [Object], [Union], [Alias] and
+// [Primitive].
+//
+//sumtype:decl
+type Atom interface {
+	isAtom()
+}
+
+// Object represents an atom naming an object: a definition with fields of its
+// own.
+type Object struct {
+	name model.Name
+}
+
+// NewObject constructs an object atom from the name of the object it names.
+func NewObject(name model.Name) Object {
+	return Object{name: name}
+}
+
+// Name returns the name of the object the atom names.
+func (o Object) Name() model.Name {
+	return o.name
+}
+
+func (Object) isAtom() {}
+
+// Union represents an atom naming a union: a definition standing for one of
+// several variants.
+type Union struct {
+	name model.Name
+}
+
+// NewUnion constructs a union atom from the name of the union it names.
+func NewUnion(name model.Name) Union {
+	return Union{name: name}
+}
+
+// Name returns the name of the union the atom names.
+func (u Union) Name() model.Name {
+	return u.name
+}
+
+func (Union) isAtom() {}
+
+// Alias represents an atom naming an alias: a name tgen gives a type the
+// documentation leaves unnamed. It carries the type it stands for, since a
+// target renders an alias by name but has to know what is underneath to spell
+// its zero value.
+type Alias struct {
+	name  model.Name
+	under Type
+}
+
+// NewAlias constructs an alias atom from the name of the alias and the type it
+// stands for.
+func NewAlias(name model.Name, under Type) Alias {
+	return Alias{name: name, under: under}
+}
+
+// Name returns the name of the alias the atom names.
+func (a Alias) Name() model.Name {
+	return a.name
+}
+
+// Under returns the type the alias stands for.
+func (a Alias) Under() Type {
+	return a.under
+}
+
+func (Alias) isAtom() {}
+
+// Primitive represents an atom naming a built-in type.
+type Primitive struct {
+	kind primitive.Kind
+}
+
+// NewPrimitive constructs a primitive atom of the given kind.
+func NewPrimitive(kind primitive.Kind) Primitive {
+	return Primitive{kind: kind}
+}
+
+// Kind returns the built-in type the atom names.
+func (p Primitive) Kind() primitive.Kind {
+	return p.kind
+}
+
+func (Primitive) isAtom() {}

--- a/model/typebound/typebound.go
+++ b/model/typebound/typebound.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package typebound models a field type as a resolved atom repeated over a
+// number of dimensions. It is the last of tgen's three type languages: a
+// typeform atom addresses a definition by reference, a typebound atom carries
+// what that reference named, so a consumer renders a type without consulting a
+// table. Nothing rewrites a definition after a type is bound to one, which is
+// what makes carrying it safe.
+package typebound
+
+import (
+	"github.com/andreychh/tgen/model/typeform"
+)
+
+// Type represents a field or return type as the resolved atom it ultimately
+// holds and the number of dimensions over which that atom repeats. The zero
+// value holds no atom and is not a valid type.
+type Type struct {
+	atom Atom
+	dim  typeform.Dimensionality
+}
+
+// NewType constructs a type from its resolved atom and dimensionality.
+func NewType(atom Atom, dim typeform.Dimensionality) Type {
+	return Type{atom: atom, dim: dim}
+}
+
+// Atom returns the resolved atom the type ultimately holds.
+func (t Type) Atom() Atom {
+	return t.atom
+}
+
+// Dimensionality returns the number of dimensions over which the type's atom
+// repeats.
+func (t Type) Dimensionality() typeform.Dimensionality {
+	return t.dim
+}

--- a/model/typeform/typeform.go
+++ b/model/typeform/typeform.go
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 // Package typeform models a field type as an atom repeated over a number of
-// dimensions. It is the narrower of tgen's two type languages: the typeexpr
+// dimensions. It is the middle of tgen's three type languages: the typeexpr
 // tree can write every type the documentation composes, including a union,
-// while a typeform type cannot spell a union at all.
+// while a typeform type cannot spell a union at all; the typebound type it
+// narrows to holds what its atom names instead of a reference to it.
 package typeform
 
 // Dimensionality is the number of array wrappers enclosing an atom: zero for a

--- a/output/mold.go
+++ b/output/mold.go
@@ -5,6 +5,8 @@ package output
 
 import (
 	"embed"
+	"fmt"
+	"strings"
 	"text/template"
 )
 
@@ -21,10 +23,35 @@ func NewMold(fs embed.FS, funcs template.FuncMap) Mold {
 }
 
 // Template parses all templates in the embedded filesystem and returns a
-// configured [template.Template].
+// configured [template.Template]. Beside the configured function map, the
+// returned template exposes two functions letting a caller dispatch on a name
+// computed from the data: render, which executes the template named by its
+// first argument against its second and yields the rendered text, and
+// override, which names the template rendering one definition: the block
+// written by hand for the reference it takes when the templates hold one, and
+// the shape it takes otherwise.
 func (m Mold) Template() (*template.Template, error) {
-	return template.New("").
-		Option("missingkey=error").
-		Funcs(m.funcs).
-		ParseFS(m.fs, "templates/*.tmpl")
+	tmpl := template.New("").Option("missingkey=error").Funcs(m.funcs)
+	return tmpl.Funcs(template.FuncMap{
+		"render": func(name string, data any) (string, error) {
+			var b strings.Builder
+			err := tmpl.ExecuteTemplate(&b, name, data)
+			if err != nil {
+				return "", fmt.Errorf("rendering %q: %w", name, err)
+			}
+			return b.String(), nil
+		},
+		// "manual_" prefixes the name of a template written by hand for one definition,
+		// holding such names in a namespace of their own. A definition is addressed by
+		// a reference the documentation gives it, a shape by a name a target chooses;
+		// the prefix keeps a target from ever choosing a name a reference already
+		// answers to, which would take a declaration over without saying so anywhere.
+		"override": func(ref, shape string) string {
+			name := "manual_" + ref
+			if tmpl.Lookup(name) == nil {
+				return shape
+			}
+			return name
+		},
+	}).ParseFS(m.fs, "templates/*.tmpl")
 }

--- a/targets/golangv2/alias.go
+++ b/targets/golangv2/alias.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	ir "github.com/andreychh/tgen/model/ir/v2"
+)
+
+// Alias represents the Go declaration of a name tgen gives a type the
+// documentation leaves unnamed.
+type Alias struct {
+	inner ir.Alias
+}
+
+// NewAlias creates an Alias from the record of an alias.
+func NewAlias(a ir.Alias) Alias {
+	return Alias{inner: a}
+}
+
+// Doc returns the doc comment of the declaration. An alias carries no link
+// back to the documentation: tgen introduces it, so no section documents it.
+func (a Alias) Doc() string {
+	return NewTypeGodoc(a.inner.Description).Value()
+}
+
+// Ref implements [Declaration].
+func (a Alias) Ref() string {
+	return string(a.inner.Ref)
+}
+
+// Template implements [Declaration].
+func (a Alias) Template() string {
+	return "alias"
+}
+
+// Name returns the Go name the alias declares.
+func (a Alias) Name() string {
+	return NewName(a.inner.Name).Value()
+}
+
+// Type returns the Go type expression the alias declares its name for.
+func (a Alias) Type() string {
+	return NewRequiredType(a.inner.Type).Value()
+}

--- a/targets/golangv2/declaration.go
+++ b/targets/golangv2/declaration.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"fmt"
+
+	ir "github.com/andreychh/tgen/model/ir/v2"
+)
+
+// Declaration represents one declaration of the generated package. The file
+// walking the sequence knows only two things about it: the template rendering
+// its shape and the reference a block written by hand claims it by. What that
+// template reads is the business of the view behind it, and no two views need
+// have anything else in common.
+type Declaration interface {
+	// Ref returns the reference the declaration is addressed by. A block written
+	// by hand claims the declaration by that reference, which no target respells.
+	Ref() string
+	// Template returns the name of the template rendering the declaration.
+	Template() string
+}
+
+// NewDeclaration creates the declaration one record of the pipeline's exit is
+// rendered as.
+func NewDeclaration(record ir.Definition) Declaration {
+	switch record := record.(type) {
+	case ir.Object:
+		return NewObject(record)
+	case ir.DiscriminatedObject:
+		return NewDiscriminatedObject(record)
+	case ir.Union:
+		return NewUnion(record)
+	case ir.DiscriminatedUnion:
+		return NewDiscriminatedUnion(record)
+	case ir.Alias:
+		return NewAlias(record)
+	case ir.Method:
+		return NewMethod(record)
+	default:
+		panic(fmt.Sprintf("golangv2: unknown definition %T", record))
+	}
+}

--- a/targets/golangv2/definition_doc.go
+++ b/targets/golangv2/definition_doc.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"slices"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/targets"
+)
+
+// DefinitionDoc represents the doc comment of a documented definition: the
+// prose of its section followed by a link back to that section.
+type DefinitionDoc struct {
+	ref     model.Reference
+	passage prose.Passage
+}
+
+// NewDefinitionDoc creates a DefinitionDoc for the definition at ref from the
+// prose of its section.
+func NewDefinitionDoc(ref model.Reference, passage prose.Passage) DefinitionDoc {
+	return DefinitionDoc{ref: ref, passage: passage}
+}
+
+// Value returns the doc comment, closing with the URL of the section.
+func (d DefinitionDoc) Value() string {
+	return NewTypeGodoc(
+		prose.NewPassage(append(
+			slices.Clone(d.passage.Blocks()),
+			prose.NewParagraph(prose.NewText(
+				"See "+targets.NewTelegramURL(d.ref).Value(),
+				prose.StylePlain,
+			)),
+		)...),
+	).Value()
+}

--- a/targets/golangv2/discriminated_object.go
+++ b/targets/golangv2/discriminated_object.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	ir "github.com/andreychh/tgen/model/ir/v2"
+	"github.com/andreychh/tgen/pkg/slices"
+)
+
+// DiscriminatedObject represents the Go declaration of an object a union tells
+// apart by a discriminator: the struct itself and the marshaller writing the
+// fixed value it is told apart by. The value is written, never declared, so no
+// variant can be built claiming to be another.
+type DiscriminatedObject struct {
+	inner ir.DiscriminatedObject
+}
+
+// NewDiscriminatedObject creates a DiscriminatedObject from the record of a
+// discriminated object.
+func NewDiscriminatedObject(o ir.DiscriminatedObject) DiscriminatedObject {
+	return DiscriminatedObject{inner: o}
+}
+
+// Doc returns the doc comment of the declaration, closing with a link back to
+// the section the object was read from.
+func (o DiscriminatedObject) Doc() string {
+	return NewDefinitionDoc(o.inner.Ref, o.inner.Description).Value()
+}
+
+// Ref implements [Declaration].
+func (o DiscriminatedObject) Ref() string {
+	return string(o.inner.Ref)
+}
+
+// Template implements [Declaration].
+func (o DiscriminatedObject) Template() string {
+	return "discriminated_object"
+}
+
+// Name returns the Go name the object declares.
+func (o DiscriminatedObject) Name() string {
+	return NewName(o.inner.Name).Value()
+}
+
+// Fields returns the fields the object declares, in the order the documentation
+// listed them. The discriminating field is not among them.
+func (o DiscriminatedObject) Fields() []Field {
+	return slices.NewMapped(o.inner.Fields, NewField)
+}
+
+// Unions returns the fields the object has to decode by hand, empty when
+// encoding/json decodes it on its own.
+func (o DiscriminatedObject) Unions() []UnionField {
+	return NewUnionFields(o.inner.Fields).Value()
+}
+
+// Files returns the fields the object has to hand a file over for, empty when
+// it holds none and so rides its marshaller outbound.
+func (o DiscriminatedObject) Files() []Attached {
+	return slices.NewMapped(o.inner.Files, NewAttached)
+}
+
+// Rewrites reports whether the object has to rewrite itself into JSON because a
+// union reaching a file admits it. An object holding a file of its own rewrites
+// itself anyway; this is what obliges the ones holding none.
+func (o DiscriminatedObject) Rewrites() bool {
+	return o.inner.Rewrites
+}
+
+// Discriminator returns the field the object is marshalled with.
+func (o DiscriminatedObject) Discriminator() Discriminator {
+	return NewDiscriminator(o.inner.Discriminator)
+}

--- a/targets/golangv2/discriminator.go
+++ b/targets/golangv2/discriminator.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"fmt"
+
+	ir "github.com/andreychh/tgen/model/ir/v2"
+	"github.com/andreychh/tgen/model/primitive"
+)
+
+// Discriminator represents the field a discriminated object is marshalled
+// with. It is declared by no struct: the marshaller writes it into a shadow of
+// the object, holding a constant no caller can set.
+type Discriminator struct {
+	inner ir.Discriminator
+}
+
+// NewDiscriminator creates a Discriminator from the record of a discriminator.
+func NewDiscriminator(d ir.Discriminator) Discriminator {
+	return Discriminator{inner: d}
+}
+
+// Name returns the Go name of the field.
+func (d Discriminator) Name() string {
+	return NewNameFromKey(d.inner.Key).Value()
+}
+
+// Type returns the Go type of the field. A discriminating value is a keyword
+// the documentation writes as text, so Go declares it a string.
+func (d Discriminator) Type() string {
+	return builtin(primitive.String)
+}
+
+// Tag returns the struct tag of the field. The field is always written, so it
+// is never omitted.
+func (d Discriminator) Tag() string {
+	return NewTag(d.inner.Key, false).Value()
+}
+
+// Value returns the constant the field holds, quoted as a Go string literal.
+func (d Discriminator) Value() string {
+	return fmt.Sprintf("%q", d.inner.Value)
+}

--- a/targets/golangv2/field.go
+++ b/targets/golangv2/field.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	ir "github.com/andreychh/tgen/model/ir/v2"
+)
+
+// Field represents the Go declaration of a field an object owns or a parameter
+// a method takes.
+type Field struct {
+	inner ir.Field
+}
+
+// NewField creates a Field from the record of a field.
+func NewField(f ir.Field) Field {
+	return Field{inner: f}
+}
+
+// Doc returns the doc comment of the declaration.
+func (f Field) Doc() string {
+	return NewFieldGodoc(f.inner.Description).Value()
+}
+
+// Name returns the Go name the field declares.
+func (f Field) Name() string {
+	return NewNameFromKey(f.inner.Key).Value()
+}
+
+// Type returns the Go type expression of the field.
+func (f Field) Type() string {
+	return NewType(f.inner.Type, f.inner.Optionality).Value()
+}
+
+// Tag returns the struct tag of the field.
+func (f Field) Tag() string {
+	return NewTag(f.inner.Key, f.inner.Optionality).Value()
+}

--- a/targets/golangv2/file_field.go
+++ b/targets/golangv2/file_field.go
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"github.com/iancoleman/strcase"
+
+	"github.com/andreychh/tgen/model"
+	ir "github.com/andreychh/tgen/model/ir/v2"
+)
+
+// filed represents what every file field holds whatever hands its file over:
+// the declaration it shadows, and the local the handed-over value waits in.
+type filed struct {
+	inner ir.FileField
+}
+
+// Name returns the Go name of the declaration, which the shadow declares too.
+func (f filed) Name() string {
+	return NewNameFromKey(f.inner.Key).Value()
+}
+
+// Key returns the encoded key of the declaration.
+func (f filed) Key() string {
+	return string(f.inner.Key)
+}
+
+// Local returns the name of the local the handed-over value is held in until
+// the shadow is assembled.
+func (f filed) Local() string {
+	return strcase.ToLowerCamel(string(f.inner.Key))
+}
+
+// Tag returns the struct tag of the shadow, omitting an optional declaration
+// the caller left unset.
+func (f filed) Tag() string {
+	return NewTag(f.inner.Key, f.inner.Optionality).Value()
+}
+
+// Array reports whether the declaration holds a sequence, each element of which
+// hands its own file over.
+func (f filed) Array() bool {
+	return f.inner.Type.Dimensionality() > 0
+}
+
+// Optional reports whether the caller may leave the declaration unset, which
+// leaves nothing to hand over.
+func (f filed) Optional() bool {
+	return bool(f.inner.Optionality)
+}
+
+// file reports whether the declaration is the file itself rather than something
+// holding one inside.
+func (f filed) file() bool {
+	return f.inner.Kind == model.FileKindFile
+}
+
+// carried returns the Go type a declaration holding a file inside is shadowed
+// by. It rewrites itself into JSON wherever it sits, so where it sits does not
+// change the answer.
+func (f filed) carried() string {
+	if f.Array() {
+		return "[]json.RawMessage"
+	}
+	return "json.RawMessage"
+}
+
+// carrying returns the name of the template handing over the file a declaration
+// holds inside, which for the same reason does not depend on where it sits.
+func (f filed) carrying() string {
+	if f.Array() {
+		return "file_resolve_array"
+	}
+	return "file_resolve"
+}
+
+// Placed represents a parameter of a method that reaches a file. A parameter
+// owns a key of the request, so its file travels in a part named by that key
+// and leaves behind the reference the sink wrote for it.
+type Placed struct {
+	filed
+}
+
+// NewPlaced creates a Placed from the record of a parameter reaching a file.
+func NewPlaced(f ir.FileField) Placed {
+	return Placed{filed: filed{inner: f}}
+}
+
+// Receiver returns the name the enclosing method's receiver is written as.
+func (Placed) Receiver() string {
+	return "m"
+}
+
+// Fail returns the statement propagating err out of the enclosing method.
+func (Placed) Fail() string {
+	return "return formPayload{}, err"
+}
+
+// Shadow returns the Go type standing in for the declared one. Placing a file
+// yields a reference only when the caller set one, so it is always a pointer.
+func (p Placed) Shadow() string {
+	if p.file() {
+		return "*string"
+	}
+	return p.carried()
+}
+
+// Template returns the name of the template handing the file over.
+func (p Placed) Template() string {
+	if p.file() {
+		return "file_place"
+	}
+	return p.carrying()
+}
+
+// Attached represents a field of an object that reaches a file. An object sits
+// inside a value of the request and owns no key of it, so its file travels in a
+// part under a generated key and leaves behind a reference to that key.
+type Attached struct {
+	filed
+}
+
+// NewAttached creates an Attached from the record of a field reaching a file.
+func NewAttached(f ir.FileField) Attached {
+	return Attached{filed: filed{inner: f}}
+}
+
+// Receiver returns the name the enclosing method's receiver is written as.
+func (Attached) Receiver() string {
+	return "o"
+}
+
+// Fail returns the statement propagating err out of the enclosing method.
+func (Attached) Fail() string {
+	return "return nil, err"
+}
+
+// Shadow returns the Go type standing in for the declared one. Attaching a file
+// always yields a reference, so only an optional field needs a pointer to tell
+// an unset one from a reference to nothing.
+func (a Attached) Shadow() string {
+	if !a.file() {
+		return a.carried()
+	}
+	if a.Optional() {
+		return "*string"
+	}
+	return "string"
+}
+
+// Template returns the name of the template handing the file over.
+func (a Attached) Template() string {
+	if a.file() {
+		return "file_attach"
+	}
+	return a.carrying()
+}

--- a/targets/golangv2/godoc.go
+++ b/targets/golangv2/godoc.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"strings"
+
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/mitchellh/go-wordwrap"
+)
+
+// width is the room left for doc text once the comment marker is written.
+const width = 77
+
+// Godoc represents a prose passage rendered as a Go doc comment: a paragraph
+// per block, lists in the bullet form gofmt reflows, and one comment marker per
+// line. The first line carries no indentation, since whatever declares the
+// commented name has already written it.
+type Godoc struct {
+	passage prose.Passage
+	indent  int
+}
+
+// NewGodoc creates a Godoc rendering a passage at an indentation depth.
+func NewGodoc(passage prose.Passage, indent int) Godoc {
+	return Godoc{passage: passage, indent: indent}
+}
+
+// NewTypeGodoc creates a Godoc for a name declared at file scope.
+func NewTypeGodoc(passage prose.Passage) Godoc {
+	return NewGodoc(passage, 0)
+}
+
+// NewFieldGodoc creates a Godoc for a name declared inside a struct. A field
+// is described by a table cell, which holds inline prose only, so its one
+// phrase becomes the single paragraph of a passage.
+func NewFieldGodoc(phrase prose.Phrase) Godoc {
+	return NewGodoc(prose.NewPassage(prose.NewParagraph(phrase.Inlines()...)), 1)
+}
+
+// Value returns the doc comment, empty when the passage writes no prose. A
+// block that writes nothing takes no line and earns no blank line beside it,
+// so an empty paragraph leaves no trace rather than an empty comment.
+func (d Godoc) Value() string {
+	lines := make([]string, 0)
+	for _, block := range d.passage.Blocks() {
+		written := d.block(block)
+		if len(written) == 0 {
+			continue
+		}
+		if len(lines) > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, written...)
+	}
+	return d.comment(lines)
+}
+
+// block returns the lines one block occupies.
+func (d Godoc) block(block prose.Block) []string {
+	switch block := block.(type) {
+	case prose.Paragraph:
+		return wrap(text(block.Inlines()), width, "", "")
+	case prose.List:
+		return d.list(block)
+	default:
+		return nil
+	}
+}
+
+// list returns the lines a list occupies, each item written in the bullet form
+// a Go doc comment recognises.
+func (d Godoc) list(list prose.List) []string {
+	lines := make([]string, 0, len(list.Items()))
+	for _, item := range list.Items() {
+		lines = append(lines, wrap(text(item.Inlines()), width-4, "  - ", "    ")...)
+	}
+	return lines
+}
+
+// comment returns the lines written as a doc comment, every line after the
+// first indented to the depth the declaration sits at.
+func (d Godoc) comment(lines []string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	pad := strings.Repeat("\t", d.indent)
+	out := make([]string, 0, len(lines))
+	for i, line := range lines {
+		out = append(out, strings.TrimRight(marker(pad, i == 0)+line, " "))
+	}
+	return strings.Join(out, "\n")
+}
+
+// marker returns the comment marker a line opens with.
+func marker(pad string, first bool) string {
+	if first {
+		return "// "
+	}
+	return pad + "// "
+}
+
+// text returns the plain text of inline content. A link contributes its text
+// alone: the anchor it addresses is not yet resolved to the name a Go doc link
+// would have to spell.
+func text(inlines []prose.Inline) string {
+	var out strings.Builder
+	for _, inline := range inlines {
+		switch inline := inline.(type) {
+		case prose.Text:
+			out.WriteString(inline.Content())
+		case prose.Link:
+			out.WriteString(inline.Content())
+		case prose.LineBreak:
+			out.WriteString("\n")
+		}
+	}
+	return out.String()
+}
+
+// wrap returns content folded to the given width, opening with first and
+// continuing with rest. A forced line break in the content starts a new line of
+// its own. Content with nothing to read folds to no lines at all.
+func wrap(content string, width int, first, rest string) []string {
+	if strings.TrimSpace(content) == "" {
+		return nil
+	}
+	out := make([]string, 0)
+	for segment := range strings.SplitSeq(content, "\n") {
+		folded := wordwrap.WrapString(segment, uint(width))
+		for line := range strings.SplitSeq(folded, "\n") {
+			out = append(out, rest+line)
+		}
+	}
+	out[0] = first + strings.TrimPrefix(out[0], rest)
+	return out
+}

--- a/targets/golangv2/method.go
+++ b/targets/golangv2/method.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	ir "github.com/andreychh/tgen/model/ir/v2"
+	"github.com/andreychh/tgen/pkg/slices"
+)
+
+// Method represents the Go declaration of a documented method: the struct
+// holding its parameters, the payload that struct is sent as, and the response
+// its Call decodes.
+type Method struct {
+	inner ir.Method
+}
+
+// NewMethod creates a Method from the record of a method.
+func NewMethod(m ir.Method) Method {
+	return Method{inner: m}
+}
+
+// Doc returns the doc comment of the declaration, closing with a link back to
+// the section the method was read from.
+func (m Method) Doc() string {
+	return NewDefinitionDoc(m.inner.Ref, m.inner.Description).Value()
+}
+
+// Ref implements [Declaration].
+func (m Method) Ref() string {
+	return string(m.inner.Ref)
+}
+
+// Template implements [Declaration].
+func (m Method) Template() string {
+	return "method"
+}
+
+// Name returns the Go name the method declares: the documented name suffixed
+// with Method, which keeps the struct holding a request apart from the object
+// the request answers with.
+func (m Method) Name() string {
+	return NewName(m.inner.Name).Value() + "Method"
+}
+
+// Wire returns the name the endpoint is called by.
+func (m Method) Wire() string {
+	return string(m.inner.Name)
+}
+
+// Fields returns the parameters the method takes, in the order the
+// documentation listed them.
+func (m Method) Fields() []Field {
+	return slices.NewMapped(m.inner.Params, NewField)
+}
+
+// Return returns the response slot of the method.
+func (m Method) Return() Return {
+	return NewResult(m.inner.Result).Return()
+}
+
+// Payload returns the request slot of the method: nothing to send when it takes
+// no parameter, a multipart body when a parameter reaches a file, and plain
+// JSON otherwise.
+func (m Method) Payload() Payload {
+	if len(m.inner.Params) == 0 {
+		return NewEmpty()
+	}
+	if len(m.inner.Files) > 0 {
+		return NewForm(slices.NewMapped(m.inner.Files, NewPlaced))
+	}
+	return NewJSON()
+}

--- a/targets/golangv2/name.go
+++ b/targets/golangv2/name.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"strings"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/iancoleman/strcase"
+)
+
+//nolint:gochecknoglobals // immutable lookup table, not mutable global state
+var acronyms = map[string]string{
+	"Id":  "ID",
+	"Url": "URL",
+	"Api": "API",
+	"Ip":  "IP",
+}
+
+// Name represents a documentation name rendered as a Go identifier.
+type Name struct {
+	inner model.Name
+}
+
+// NewName creates a Name from a documentation name.
+func NewName(n model.Name) Name {
+	return Name{inner: n}
+}
+
+// NewNameFromKey creates a Name from a field key.
+func NewNameFromKey(k model.Key) Name {
+	return NewName(model.Name(k))
+}
+
+// Value returns the name in Go's exported camel case, with the acronyms Go
+// spells in capitals restored.
+func (n Name) Value() string {
+	camel := strcase.ToCamel(string(n.inner))
+	for wrong, right := range acronyms {
+		camel = strings.ReplaceAll(camel, wrong, right)
+	}
+	return camel
+}

--- a/targets/golangv2/object.go
+++ b/targets/golangv2/object.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	ir "github.com/andreychh/tgen/model/ir/v2"
+	"github.com/andreychh/tgen/pkg/slices"
+)
+
+// Object represents the Go declaration of a documented object.
+type Object struct {
+	inner ir.Object
+}
+
+// NewObject creates an Object from the record of an object.
+func NewObject(o ir.Object) Object {
+	return Object{inner: o}
+}
+
+// Doc returns the doc comment of the declaration, closing with a link back to
+// the section the object was read from.
+func (o Object) Doc() string {
+	return NewDefinitionDoc(o.inner.Ref, o.inner.Description).Value()
+}
+
+// Ref implements [Declaration].
+func (o Object) Ref() string {
+	return string(o.inner.Ref)
+}
+
+// Template implements [Declaration].
+func (o Object) Template() string {
+	return "object"
+}
+
+// Name returns the Go name the object declares.
+func (o Object) Name() string {
+	return NewName(o.inner.Name).Value()
+}
+
+// Fields returns the fields the object declares, in the order the documentation
+// listed them.
+func (o Object) Fields() []Field {
+	return slices.NewMapped(o.inner.Fields, NewField)
+}
+
+// Unions returns the fields the object has to decode by hand, empty when
+// encoding/json decodes it on its own.
+func (o Object) Unions() []UnionField {
+	return NewUnionFields(o.inner.Fields).Value()
+}
+
+// Files returns the fields the object has to hand a file over for, empty when
+// it holds none and so rides encoding/json outbound too.
+func (o Object) Files() []Attached {
+	return slices.NewMapped(o.inner.Files, NewAttached)
+}
+
+// Rewrites reports whether the object has to rewrite itself into JSON because a
+// union reaching a file admits it. An object holding a file of its own rewrites
+// itself anyway; this is what obliges the ones holding none.
+func (o Object) Rewrites() bool {
+	return o.inner.Rewrites
+}

--- a/targets/golangv2/pass.go
+++ b/targets/golangv2/pass.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+
+	"github.com/andreychh/tgen/output"
+)
+
+//go:embed templates/*.tmpl
+var templates embed.FS
+
+// Pass is the Go generation stage: it renders the records of the pipeline's
+// exit into the files of a Go package.
+type Pass struct {
+	spec Specification
+}
+
+// NewPass creates a Pass rendering the given specification.
+func NewPass(spec Specification) Pass {
+	return Pass{spec: spec}
+}
+
+// Artifacts returns the files the target writes, each bound to the template
+// rendering it. It fails when a template is malformed.
+func (p Pass) Artifacts() (output.Artifacts, error) {
+	tmpl, err := output.NewMold(templates, template.FuncMap{}).Template()
+	if err != nil {
+		return nil, fmt.Errorf("preparing template: %w", err)
+	}
+	return output.Artifacts{
+		"api.go":    output.NewTemplateView(tmpl, "api", p.spec),
+		"client.go": output.NewTemplateView(tmpl, "client", p.spec),
+	}, nil
+}

--- a/targets/golangv2/payload.go
+++ b/targets/golangv2/payload.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+// Payload represents the request slot of a generated method: the concrete type
+// its payload method returns, and the template that renders that method's body.
+// The variants are exclusive — a method assembles its request exactly one way.
+//
+//sumtype:decl
+type Payload interface {
+	// Type returns the payload type the payload method hands back.
+	Type() string
+	// Template returns the name of the template rendering the payload body.
+	Template() string
+
+	isPayload()
+}
+
+// Empty represents the request of a method that takes no parameters, carrying
+// neither a body nor a content type.
+type Empty struct{}
+
+// NewEmpty creates an Empty.
+func NewEmpty() Empty {
+	return Empty{}
+}
+
+// Type implements [Payload].
+func (Empty) Type() string {
+	return "emptyPayload"
+}
+
+// Template implements [Payload].
+func (Empty) Template() string {
+	return "payload_empty"
+}
+
+func (Empty) isPayload() {}
+
+// JSON represents the request of a method that reaches no file, marshalled
+// whole from the method struct.
+type JSON struct{}
+
+// NewJSON creates a JSON.
+func NewJSON() JSON {
+	return JSON{}
+}
+
+// Type implements [Payload].
+func (JSON) Type() string {
+	return "jsonPayload"
+}
+
+// Template implements [Payload].
+func (JSON) Template() string {
+	return "payload_json"
+}
+
+func (JSON) isPayload() {}
+
+// Form represents the request of a method reaching a file. A file cannot travel
+// inside JSON, so every file the parameters reach is collected into a part of
+// its own and the body is rewritten to point at those parts.
+type Form struct {
+	files []Placed
+}
+
+// NewForm creates a Form from the parameters reaching a file.
+func NewForm(files []Placed) Form {
+	return Form{files: files}
+}
+
+// Type implements [Payload].
+func (Form) Type() string {
+	return "formPayload"
+}
+
+// Template implements [Payload].
+func (Form) Template() string {
+	return "payload_form"
+}
+
+// Files returns the parameters that hand a file over, in the order the
+// documentation listed them.
+func (f Form) Files() []Placed {
+	return f.files
+}
+
+func (Form) isPayload() {}

--- a/targets/golangv2/return.go
+++ b/targets/golangv2/return.go
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"fmt"
+
+	ir "github.com/andreychh/tgen/model/ir/v2"
+)
+
+// Return represents the response slot of a generated method: the result list of
+// its Call, the statement that propagates a failure out of Call, and the
+// template that renders the response body.
+//
+//sumtype:decl
+type Return interface {
+	// Signature returns the result list of Call, parenthesised when the method
+	// carries a value.
+	Signature() string
+	// Fail returns the statement propagating err out of Call.
+	Fail() string
+	// Template returns the name of the template rendering the response body.
+	Template() string
+
+	isReturn()
+}
+
+// Command represents a return that only signals success.
+type Command struct{}
+
+// NewCommand creates a Command.
+func NewCommand() Command {
+	return Command{}
+}
+
+// Signature implements [Return].
+func (Command) Signature() string {
+	return "error"
+}
+
+// Fail implements [Return].
+func (Command) Fail() string {
+	return "return err"
+}
+
+// Template implements [Return].
+func (Command) Template() string {
+	return "return_command"
+}
+
+func (Command) isReturn() {}
+
+// typed represents the response type shared by every [Return] that carries one.
+type typed struct {
+	typ Type
+}
+
+// Signature implements [Return].
+func (t typed) Signature() string {
+	return "(" + t.typ.Value() + ", error)"
+}
+
+// Fail implements [Return].
+func (t typed) Fail() string {
+	return "return " + t.typ.Zero() + ", err"
+}
+
+// Value returns the rendered response type.
+func (t typed) Value() string {
+	return t.typ.Value()
+}
+
+// Name returns the Go name of the response type, without the slices enclosing
+// it.
+func (t typed) Name() string {
+	return t.typ.Name()
+}
+
+// Plain represents a return decoded straight into its Go type.
+type Plain struct {
+	typed
+}
+
+// NewPlain creates a Plain from a response type.
+func NewPlain(typ Type) Plain {
+	return Plain{typed: typed{typ: typ}}
+}
+
+// Template implements [Return].
+func (Plain) Template() string {
+	return "return_plain"
+}
+
+func (Plain) isReturn() {}
+
+// Dispatched represents a return decoded raw and handed to the unmarshaller of
+// a union, since encoding/json cannot decode into an interface on its own.
+type Dispatched struct {
+	typed
+}
+
+// NewDispatched creates a Dispatched from a response type.
+func NewDispatched(typ Type) Dispatched {
+	return Dispatched{typed: typed{typ: typ}}
+}
+
+// Template implements [Return].
+func (Dispatched) Template() string {
+	return "return_union"
+}
+
+func (Dispatched) isReturn() {}
+
+// DispatchedArray represents a return handed to the unmarshaller of a union one
+// element at a time.
+type DispatchedArray struct {
+	typed
+}
+
+// NewDispatchedArray creates a DispatchedArray from a response type.
+func NewDispatchedArray(typ Type) DispatchedArray {
+	return DispatchedArray{typed: typed{typ: typ}}
+}
+
+// Template implements [Return].
+func (DispatchedArray) Template() string {
+	return "return_union_array"
+}
+
+func (DispatchedArray) isReturn() {}
+
+// Result represents the Go view of what a method returns.
+type Result struct {
+	inner ir.Result
+}
+
+// NewResult creates a Result from a resolved method result.
+func NewResult(r ir.Result) Result {
+	return Result{inner: r}
+}
+
+// Return returns the [Return] variant rendering the result.
+func (r Result) Return() Return {
+	switch inner := r.inner.(type) {
+	case ir.Confirmation:
+		return NewCommand()
+	case ir.Value:
+		return r.carried(NewRequiredType(inner.Type()))
+	default:
+		panic(fmt.Sprintf("golangv2: unknown result %T", inner))
+	}
+}
+
+// carried returns the variant rendering a result that carries a type: a union
+// is decoded raw and dispatched, one element at a time when it arrives as an
+// array, and everything else decodes straight into its Go type.
+func (r Result) carried(typ Type) Return {
+	if !typ.Union() {
+		return NewPlain(typ)
+	}
+	if typ.Array() {
+		return NewDispatchedArray(typ)
+	}
+	return NewDispatched(typ)
+}

--- a/targets/golangv2/specification.go
+++ b/targets/golangv2/specification.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package golangv2 renders the records of the pipeline's exit as Go source: it
+// spells every type the way Go spells it and picks, for each method, the
+// template that assembles its request and the one that decodes its response.
+package golangv2
+
+import (
+	"fmt"
+
+	ir "github.com/andreychh/tgen/model/ir/v2"
+	"github.com/andreychh/tgen/pkg/slices"
+)
+
+// Specification represents the Go view of the specification: the declarations
+// each generated file is rendered from.
+type Specification struct {
+	inner ir.Specification
+	pkg   string
+}
+
+// NewSpecification creates a Specification over the records of the pipeline's
+// exit, rendered into the package named pkg.
+func NewSpecification(inner ir.Specification, pkg string) Specification {
+	return Specification{inner: inner, pkg: pkg}
+}
+
+// Package returns the name of the package the generated files declare.
+func (s Specification) Package() string {
+	return s.pkg
+}
+
+// Definitions returns the declarations the generated package holds, ordered by
+// the position the source of each record gave it. It fails when a record cannot
+// be read as the declaration it is rendered as.
+func (s Specification) Definitions() ([]Declaration, error) {
+	records, err := s.inner.Definitions()
+	if err != nil {
+		return nil, fmt.Errorf("reading definitions: %w", err)
+	}
+	return slices.NewMapped(records, NewDeclaration), nil
+}

--- a/targets/golangv2/tag.go
+++ b/targets/golangv2/tag.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+)
+
+// Tag represents the struct tag a field carries, telling encoding/json the key
+// it reads and writes.
+type Tag struct {
+	key model.Key
+	opt model.Optionality
+}
+
+// NewTag creates a Tag from a field key and its optionality.
+func NewTag(key model.Key, opt model.Optionality) Tag {
+	return Tag{key: key, opt: opt}
+}
+
+// Value returns the tag, omitting an optional field from the encoded object
+// when it carries nothing.
+func (t Tag) Value() string {
+	if t.opt {
+		return fmt.Sprintf("`json:\"%s,omitempty\"`", t.key)
+	}
+	return fmt.Sprintf("`json:%q`", t.key)
+}

--- a/targets/golangv2/templates/api.tmpl
+++ b/targets/golangv2/templates/api.tmpl
@@ -1,0 +1,33 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	api writes everything the documentation page dictates, in the order the page
+	dictates it. The page numbers its headings in a single run and mixes types
+	with the methods that use them — Sticker beside sendSticker — so one sequence
+	is what keeps the generated file readable the way the page is. What the page
+	says nothing about is written in client.go, which changes when tgen changes
+	rather than when Telegram does.
+
+	Every declaration is rendered through the shape its kind shares, unless the
+	templates hold a block written by hand for it. Such a block claims one
+	declaration by the reference it is addressed by — manual_<ref> — and takes
+	the rendering of that declaration over, for the shapes spell what the
+	documentation says and some of what Go says is not said there. The block
+	stands where the declaration stands, so what is written by hand keeps the
+	order of the page like everything else.
+*/}}
+{{- define "api"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Specification*/ -}}
+package {{.Package}}
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+{{- range .Definitions}}
+{{render (override .Ref .Template) .}}
+{{- end}}
+{{end}}

--- a/targets/golangv2/templates/client.tmpl
+++ b/targets/golangv2/templates/client.tmpl
@@ -1,0 +1,404 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	client writes what the documentation page says nothing about: how a request
+	reaches Telegram and how the answer is split into a result or an error. None
+	of it is read from the specification, so none of it changes when Telegram
+	changes a type — it changes when tgen changes its mind about sending. That is
+	the whole reason it is a file of its own rather than the tail of api.go.
+
+	The names api.go leans on from here are the two payload constructors, the
+	sink a file is handed to, and Connection itself.
+*/}}
+{{- define "client"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Specification*/ -}}
+package {{.Package}}
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+)
+
+// Method is the name an endpoint is called by.
+type Method string
+
+// Payload is the body of one request, which knows how to become that request.
+type Payload interface {
+	Request(ctx context.Context, method, url string) (*http.Request, error)
+}
+
+var (
+	_ Payload = emptyPayload{}
+	_ Payload = jsonPayload{}
+	_ Payload = formPayload{}
+)
+
+// Connection is where a method sends its payload and where the decoded result
+// comes back from.
+type Connection interface {
+	Do(ctx context.Context, method Method, payload Payload, response any) error
+}
+
+// HTTPConnection is the production Connection: it builds the request from the
+// payload, posts it to the Telegram endpoint, and splits the JSON envelope into
+// either a decoded result or an Error.
+type HTTPConnection struct {
+	client      *http.Client
+	destination Destination
+}
+
+// NewHTTPConnection creates an HTTPConnection to the public Telegram Bot API
+// using a bot token.
+func NewHTTPConnection(client *http.Client, token string) HTTPConnection {
+	return NewHTTPConnectionTo(client, NewDestination("https://api.telegram.org", token))
+}
+
+// NewHTTPConnectionTo creates an HTTPConnection to an explicit Destination, for
+// pointing at a self-hosted server or the test environment.
+func NewHTTPConnectionTo(client *http.Client, destination Destination) HTTPConnection {
+	return HTTPConnection{client: client, destination: destination}
+}
+
+// Do posts the payload to the method endpoint and decodes the result into
+// response. It returns an *Error when the API reports a failure, or a wrapped
+// error when the request, transport, or decoding fails.
+func (c HTTPConnection) Do(
+	ctx context.Context,
+	method Method,
+	payload Payload,
+	response any,
+) error {
+	req, err := payload.Request(ctx, http.MethodPost, c.destination.url(method))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var env envelope
+	err = json.NewDecoder(resp.Body).Decode(&env)
+	if err != nil {
+		return fmt.Errorf("decoding envelope: %w", err)
+	}
+	raw, err := env.result()
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(raw, response)
+	if err != nil {
+		return fmt.Errorf("decoding result: %w", err)
+	}
+	return nil
+}
+
+// Destination is where a bot's requests go: a base host, the bot token that
+// parameterizes the path, and whether to target Telegram's test environment. It
+// turns a method name into that method's request URL.
+type Destination struct {
+	base  string
+	token string
+	test  bool
+}
+
+// NewDestination creates a Destination targeting the production environment.
+func NewDestination(base, token string) Destination {
+	return Destination{base: base, token: token, test: false}
+}
+
+// NewTestDestination creates a Destination targeting the test environment, whose
+// path carries an extra "test" segment after the token.
+func NewTestDestination(base, token string) Destination {
+	return Destination{base: base, token: token, test: true}
+}
+
+// url returns the request URL for method.
+func (d Destination) url(method Method) string {
+	if d.test {
+		return fmt.Sprintf("%s/bot%s/test/%s", d.base, d.token, method)
+	}
+	return fmt.Sprintf("%s/bot%s/%s", d.base, d.token, method)
+}
+
+// envelope is the Telegram Bot API JSON response wrapper: exactly one side is
+// meaningful — Result when Ok, the error fields otherwise.
+type envelope struct {
+	Ok          bool                `json:"ok"`
+	Result      json.RawMessage     `json:"result,omitempty"`
+	ErrorCode   *int64              `json:"error_code,omitempty"`
+	Description *string             `json:"description,omitempty"`
+	Parameters  *ResponseParameters `json:"parameters,omitempty"`
+}
+
+// result returns the raw API result, or an *Error when the envelope reports a
+// failure.
+func (e envelope) result() (json.RawMessage, error) {
+	if e.Ok {
+		return e.Result, nil
+	}
+	code := int64(0)
+	if e.ErrorCode != nil {
+		code = *e.ErrorCode
+	}
+	description := "<no description>"
+	if e.Description != nil {
+		description = *e.Description
+	}
+	return nil, &Error{Code: code, Description: description, Parameters: e.Parameters}
+}
+
+// Error is a failure reported by the Telegram Bot API.
+type Error struct {
+	Code        int64
+	Description string
+	Parameters  *ResponseParameters
+}
+
+// Error returns the code and description as a single message.
+func (e *Error) Error() string {
+	return fmt.Sprintf("telegram %d: %s", e.Code, e.Description)
+}
+
+// emptyPayload is the body of a method with no parameter: no body, no header.
+type emptyPayload struct{}
+
+// Request implements [Payload].
+func (emptyPayload) Request(ctx context.Context, method, url string) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, method, url, http.NoBody)
+}
+
+// jsonPayload is the body of a method reaching no file: the method marshals
+// itself whole.
+type jsonPayload struct {
+	value any
+}
+
+func newJSONPayload(value any) jsonPayload {
+	return jsonPayload{value: value}
+}
+
+// Request implements [Payload].
+func (p jsonPayload) Request(ctx context.Context, method, url string) (*http.Request, error) {
+	data, err := json.Marshal(p.value)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// filePart is one binary part of a multipart request: what it is called and
+// where its bytes come from.
+type filePart struct {
+	name   string
+	reader io.Reader
+}
+
+// fileSink accumulates binary parts as the parameters reaching a file hand
+// themselves over. Its mutation is its nature: place and attach write their
+// files into it. It takes a file either under a key its caller owns, or under a
+// key it generates and gives back.
+type fileSink struct {
+	files   map[string]filePart
+	counter int
+}
+
+func newFileSink() *fileSink {
+	return &fileSink{files: map[string]filePart{}, counter: 0}
+}
+
+// file stores reader under key.
+func (s *fileSink) file(key, name string, reader io.Reader) {
+	s.files[key] = filePart{name: name, reader: reader}
+}
+
+// reserve stores reader under a freshly generated key and returns that key, for
+// use in an "attach://" reference.
+func (s *fileSink) reserve(name string, reader io.Reader) string {
+	key := fmt.Sprintf("attachment_%d", s.counter)
+	s.counter++
+	s.file(key, name, reader)
+	return key
+}
+
+// formPayload is the body of a method reaching a file: the body every parameter
+// that is not a file rides in, plus the parts the files were handed over as.
+type formPayload struct {
+	value any
+	files map[string]filePart
+}
+
+func newFormPayload(value any, files map[string]filePart) formPayload {
+	return formPayload{value: value, files: files}
+}
+
+// Request implements [Payload]. A method that could have carried a file but
+// carried none sends plain JSON, since a multipart body buys nothing then.
+func (p formPayload) Request(ctx context.Context, method, url string) (*http.Request, error) {
+	if len(p.files) == 0 {
+		return newJSONPayload(p.value).Request(ctx, method, url)
+	}
+	data, err := json.Marshal(p.value)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling payload: %w", err)
+	}
+	var fields map[string]json.RawMessage
+	err = json.Unmarshal(data, &fields)
+	if err != nil {
+		return nil, fmt.Errorf("splitting body: %w", err)
+	}
+	buf := &bytes.Buffer{}
+	writer := multipart.NewWriter(buf)
+	for key, raw := range fields {
+		value, err := formField(raw).value()
+		if err != nil {
+			return nil, err
+		}
+		err = writer.WriteField(key, value)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for key, part := range p.files {
+		into, err := writer.CreateFormFile(key, part.name)
+		if err != nil {
+			return nil, err
+		}
+		_, err = io.Copy(into, part.reader)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, nil
+}
+
+// formField is one top-level JSON value of a body rendered into a form field.
+type formField json.RawMessage
+
+// value unquotes a JSON string and keeps anything else — a number, a boolean, a
+// nested object or array — verbatim. It fails when a quoted value is not valid
+// JSON.
+func (f formField) value() (string, error) {
+	if len(f) > 0 && f[0] == '"' {
+		var unquoted string
+		err := json.Unmarshal(f, &unquoted)
+		if err != nil {
+			return "", fmt.Errorf("unquoting form field: %w", err)
+		}
+		return unquoted, nil
+	}
+	return string(f), nil
+}
+
+// Response is the canned outcome of a FakeConnection call: a value or an error.
+type Response interface{ sealedResponse() }
+
+type (
+	okResponse  struct{ value any }
+	errResponse struct{ err error }
+)
+
+func (okResponse) sealedResponse()  {}
+func (errResponse) sealedResponse() {}
+
+var (
+	_ Response = okResponse{}
+	_ Response = errResponse{}
+)
+
+// Ok creates a Response that decodes value into the call's result.
+func Ok(value any) Response { return okResponse{value: value} }
+
+// Err creates a Response that returns err as the call's error.
+func Err(err error) Response { return errResponse{err: err} }
+
+// Call pairs a Method with its canned Response.
+type Call struct {
+	method   Method
+	response Response
+}
+
+// NewCall creates a Call from a method and its canned response.
+func NewCall(method Method, response Response) Call {
+	return Call{method: method, response: response}
+}
+
+// callQueue is the mutable cursor over a fixed sequence of Calls: advancing is
+// its nature. FakeConnection delegates sequencing to it, so the connection
+// itself stays an immutable value.
+type callQueue struct {
+	calls []Call
+	index int
+}
+
+func newCallQueue(calls []Call) *callQueue {
+	return &callQueue{calls: calls, index: 0}
+}
+
+// next returns the next Call, or false once the queue is exhausted.
+func (q *callQueue) next() (Call, bool) {
+	if q.index >= len(q.calls) {
+		return Call{method: "", response: nil}, false
+	}
+	call := q.calls[q.index]
+	q.index++
+	return call, true
+}
+
+// FakeConnection replays a fixed sequence of Calls, verifying the method of
+// each. Misuse — exhaustion or a method mismatch — panics rather than errors, so
+// a wrong test fails loudly instead of silently passing.
+type FakeConnection struct {
+	queue *callQueue
+}
+
+// NewFakeConnection creates a FakeConnection over a fixed sequence of calls.
+func NewFakeConnection(calls ...Call) FakeConnection {
+	return FakeConnection{queue: newCallQueue(calls)}
+}
+
+// Do replays the next Call: it panics when the queue is exhausted or the method
+// does not match, returns the canned error, or decodes the canned value into
+// response. It mirrors HTTPConnection's decode path — marshal the canned value,
+// unmarshal into response — so a method dispatching a union behaves identically.
+func (c FakeConnection) Do(_ context.Context, method Method, _ Payload, response any) error {
+	call, ok := c.queue.next()
+	if !ok {
+		panic(fmt.Sprintf("FakeConnection: unexpected call to %q", method))
+	}
+	if call.method != method {
+		panic(fmt.Sprintf("FakeConnection: expected %q, got %q", call.method, method))
+	}
+	switch r := call.response.(type) {
+	case errResponse:
+		return r.err
+	case okResponse:
+		data, err := json.Marshal(r.value)
+		if err != nil {
+			panic(fmt.Sprintf("FakeConnection: marshaling %q response: %v", method, err))
+		}
+		return json.Unmarshal(data, response)
+	default:
+		panic(fmt.Sprintf("FakeConnection: unknown response %T", call.response))
+	}
+}
+{{end}}

--- a/targets/golangv2/templates/file.tmpl
+++ b/targets/golangv2/templates/file.tmpl
@@ -1,0 +1,83 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	The four templates below write how one declaration hands its file over. Two
+	of them turn on where the declaration sits, since only a parameter owns a
+	key of the request to name a part after. The other two do not: a declaration
+	holding a file inside rewrites itself into JSON wherever it sits, so a
+	method and an object render it the same way and read the receiver and the
+	failing return off the declaration rather than knowing them.
+*/}}
+
+{{- /*
+	file_place hands over a parameter that is the file itself. It travels in a
+	part named by the parameter's own key, and leaves behind the reference the
+	sink wrote for it.
+*/}}
+{{- define "file_place"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Placed*/}}
+{{- if .Optional}}
+	var {{.Local}} *string
+	if {{.Receiver}}.{{.Name}} != nil {
+		{{.Local}} = {{.Receiver}}.{{.Name}}.place(sink, "{{.Key}}")
+	}
+{{- else}}
+	{{.Local}} := {{.Receiver}}.{{.Name}}.place(sink, "{{.Key}}")
+{{- end}}
+{{- end}}
+
+{{- /*
+	file_attach hands over a field that is the file itself. It owns no key of
+	the request, so the sink generates one and the field is shadowed by the
+	reference to it. The reference is taken through a local, since the target
+	the generated code lands in predates taking the address of a call.
+*/}}
+{{- define "file_attach"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Attached*/}}
+{{- if .Optional}}
+	var {{.Local}} *string
+	if {{.Receiver}}.{{.Name}} != nil {
+		ref := {{.Receiver}}.{{.Name}}.attach(sink)
+		{{.Local}} = &ref
+	}
+{{- else}}
+	{{.Local}} := {{.Receiver}}.{{.Name}}.attach(sink)
+{{- end}}
+{{- end}}
+
+{{- /*
+	file_resolve hands over a declaration holding a file somewhere inside. It
+	owns no part of the form, so it rewrites itself into JSON and hands its file
+	over on the way.
+*/}}
+{{- define "file_resolve"}}
+{{- if .Optional}}
+	var {{.Local}} json.RawMessage
+	if {{.Receiver}}.{{.Name}} != nil {
+		data, err := {{.Receiver}}.{{.Name}}.resolve(sink)
+		if err != nil {
+			{{.Fail}}
+		}
+		{{.Local}} = data
+	}
+{{- else}}
+	{{.Local}}, err := {{.Receiver}}.{{.Name}}.resolve(sink)
+	if err != nil {
+		{{.Fail}}
+	}
+{{- end}}
+{{- end}}
+
+{{- /*
+	file_resolve_array does the same for a sequence, each element of which holds
+	a file of its own and rewrites itself on its own.
+*/}}
+{{- define "file_resolve_array"}}
+	{{.Local}} := make([]json.RawMessage, len({{.Receiver}}.{{.Name}}))
+	for i, el := range {{.Receiver}}.{{.Name}} {
+		data, err := el.resolve(sink)
+		if err != nil {
+			{{.Fail}}
+		}
+		{{.Local}}[i] = data
+	}
+{{- end}}

--- a/targets/golangv2/templates/manual.tmpl
+++ b/targets/golangv2/templates/manual.tmpl
@@ -1,0 +1,230 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	The blocks below are the declarations Go spells in a way the documentation
+	does not describe. Each claims one definition by the reference it is
+	addressed by, and is rendered in that definition's place, so nothing here
+	escapes the order of the page or the pass that walks it.
+
+	A block writes by hand only what has to be written by hand: it renders the
+	shape its kind shares for everything the documentation does say, and adds
+	its own beside it. Spelling a declaration out in full here would freeze
+	what the specification still owns, and the next release would drift past it
+	unnoticed.
+*/}}
+
+{{- /*
+	manual_fileid adds to the file id alias the two ways a file travels, which
+	is what makes it an InputFile: a file already held by Telegram is named,
+	never uploaded, so it stays in the body wherever it sits.
+*/}}
+{{- define "manual_fileid"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Alias*/}}
+{{- template "alias" .}}
+
+func (f {{.Name}}) place(_ *fileSink, _ string) *string {
+	ref := string(f)
+	return &ref
+}
+
+func (f {{.Name}}) attach(_ *fileSink) string {
+	return string(f)
+}
+{{- end}}
+
+{{- /*
+	manual_upload spells the upload object out, declaration and all: what it
+	holds is a stream of bytes, which the specification never names and no two
+	targets spell alike. Its two ways of travelling are the ones the union
+	exists for — a file uploaded with the request leaves the body for a part of
+	its own, so place hands it over and keeps nothing behind, while attach
+	leaves the reference the part is reached by.
+*/}}
+{{- define "manual_upload"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Object*/}}
+{{.Doc}}
+type {{.Name}} struct {
+	Name   string
+	Reader io.Reader
+}
+
+func (u {{.Name}}) place(sink *fileSink, key string) *string {
+	sink.file(key, u.name(), u.Reader)
+	return nil
+}
+
+func (u {{.Name}}) attach(sink *fileSink) string {
+	return "attach://" + sink.reserve(u.name(), u.Reader)
+}
+
+func (u {{.Name}}) name() string {
+	if u.Name == "" {
+		return "file"
+	}
+	return u.Name
+}
+{{- end}}
+
+{{- /*
+	manual_inputfile writes the union a file travels as. Its interface is the one
+	thing about a union no shape can write: the two ways of travelling are tgen's
+	invention, and every generated method reaching a file leans on them. Inbound,
+	only a file id can ever come back — an upload is a stream of bytes going one
+	way — so the decoder reads the reference and nothing else.
+*/}}
+{{- define "manual_inputfile"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- $union := .Name}}
+{{.Doc}}
+//sumtype:decl
+type {{$union}} interface {
+	place(sink *fileSink, key string) *string
+	attach(sink *fileSink) string
+	sealed{{$union}}()
+}
+{{range .Variants}}
+func ({{.Name}}) sealed{{$union}}() {}
+{{- end}}
+
+func unmarshal{{$union}}(data []byte) ({{$union}}, error) {
+	var id FileID
+	if err := json.Unmarshal(data, &id); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal %s into {{$union}}: %w", data, err)
+	}
+	return id, nil
+}
+{{- end}}
+
+{{- /*
+	manual_chatid writes the decoder of the union a chat is addressed by. The two
+	variants are told apart by what JSON they are: a number is an id, a string is
+	a username, and neither decodes as the other.
+*/}}
+{{- define "manual_chatid"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- template "union" .}}
+
+func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
+	var id ID
+	if json.Unmarshal(data, &id) == nil {
+		return id, nil
+	}
+	var username Username
+	if json.Unmarshal(data, &username) == nil {
+		return username, nil
+	}
+	return nil, fmt.Errorf("cannot unmarshal %s into {{.Name}}", data)
+}
+{{- end}}
+
+{{- /*
+	manual_maybemessage writes the decoder of the union an edit returns: the
+	edited message when the bot may read it, the True marker when the message is
+	inline and beyond reach. An object never decodes as a boolean and a boolean
+	never as an object, so trying them in turn tells them apart.
+*/}}
+{{- define "manual_maybemessage"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- template "union" .}}
+
+func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
+	var message Message
+	if json.Unmarshal(data, &message) == nil {
+		return message, nil
+	}
+	var marker True
+	if json.Unmarshal(data, &marker) == nil {
+		return marker, nil
+	}
+	return nil, fmt.Errorf("cannot unmarshal %s into {{.Name}}", data)
+}
+{{- end}}
+
+{{- /*
+	manual_maybeinaccessiblemessage writes the decoder of the union a message
+	arrives as. Both variants are objects, so trying them in turn would let the
+	first swallow the second. The documentation tells them apart by a value
+	instead: an inaccessible message always dates from zero.
+*/}}
+{{- define "manual_maybeinaccessiblemessage"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- template "union" .}}
+
+func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
+	var mark struct {
+		Date int64 `json:"date"`
+	}
+	if err := json.Unmarshal(data, &mark); err != nil {
+		return nil, err
+	}
+	if mark.Date == 0 {
+		var inaccessible InaccessibleMessage
+		if err := json.Unmarshal(data, &inaccessible); err != nil {
+			return nil, err
+		}
+		return inaccessible, nil
+	}
+	var message Message
+	if err := json.Unmarshal(data, &message); err != nil {
+		return nil, err
+	}
+	return message, nil
+}
+{{- end}}
+
+{{- /*
+	manual_inputmessagecontent writes the decoder of a union that is only ever
+	sent. Nothing tells its six variants apart: no key marks them, and every one
+	of them is an object, so trying them in turn would let the first swallow the
+	rest. Nothing has to tell them apart either — an inline result travels one way,
+	and the decoder exists only because an object holding one is declared with a
+	decoder of its own. It says so instead of guessing.
+*/}}
+{{- define "manual_inputmessagecontent"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- template "union" .}}
+
+func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
+	return nil, fmt.Errorf("{{.Name}} is only ever sent, so %s cannot be read back", data)
+}
+{{- end}}
+
+{{- /*
+	manual_richtext writes the decoder of the one union the documentation writes
+	partly as prose: two of its variants are not objects at all, so the shape of
+	the JSON tells them apart before anything else can. A string is a plain run of
+	text, an array is a sequence of runs, and everything else is one of the
+	variants a key tells apart.
+
+	That last switch is missing, and it is the one thing here that should not be
+	written by hand: twenty-five cases that drift the moment Telegram names a
+	twenty-sixth. Which is what a Union record cannot express yet — it drops the
+	marks of the variants that do carry them.
+*/}}
+{{- define "manual_richtext"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- template "union" .}}
+
+func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("cannot unmarshal an empty value into {{.Name}}")
+	}
+	switch trimmed[0] {
+	case '"':
+		var plain RichTextPlain
+		if err := json.Unmarshal(data, &plain); err != nil {
+			return nil, err
+		}
+		return plain, nil
+	case '[':
+		var raws []json.RawMessage
+		if err := json.Unmarshal(data, &raws); err != nil {
+			return nil, err
+		}
+		sequence := make(RichTextSequence, len(raws))
+		for i, raw := range raws {
+			element, err := unmarshal{{.Name}}(raw)
+			if err != nil {
+				return nil, err
+			}
+			sequence[i] = element
+		}
+		return sequence, nil
+	}
+	return nil, fmt.Errorf("cannot unmarshal %s into {{.Name}}: the marked variants are not dispatched yet", data)
+}
+{{- end}}

--- a/targets/golangv2/templates/method.tmpl
+++ b/targets/golangv2/templates/method.tmpl
@@ -1,0 +1,24 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	method writes one API method: the struct holding its parameters, the Call
+	joining the two slots, and the payload method holding the request slot on
+	its own. The struct comes from the shape every declaration with fields
+	shares, so the parameters are spelled the way an object's fields are.
+*/}}
+{{- define "method"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+{{- template "struct" .}}
+
+func (m {{.Name}}) Call(ctx context.Context, conn Connection) {{.Return.Signature}} {
+	payload, err := m.payload()
+	if err != nil {
+		{{.Return.Fail}}
+	}
+{{- render .Return.Template .}}
+}
+
+func (m {{.Name}}) payload() ({{.Payload.Type}}, error) {
+{{- render .Payload.Template .}}
+}
+{{- end}}

--- a/targets/golangv2/templates/payload.tmpl
+++ b/targets/golangv2/templates/payload.tmpl
@@ -1,0 +1,37 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- define "payload_empty"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+	return emptyPayload{}, nil
+{{- end}}
+
+{{- define "payload_json"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+	return newJSONPayload(m), nil
+{{- end}}
+
+{{- /*
+	payload_form writes the body of a method reaching a file. Every such
+	parameter hands its file to the sink and leaves behind a value pointing at
+	it; the body then shadows the parameter with that value, and rides the alias
+	for everything else. The alias is a defined type and holds no method, so the
+	shadow is what encoding/json writes.
+*/}}
+{{- define "payload_form"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+	sink := newFileSink()
+{{- range .Payload.Files}}
+{{- render .Template .}}
+{{- end}}
+	type alias {{.Name}}
+	body := struct {
+{{- range .Payload.Files}}
+		{{.Name}} {{.Shadow}} {{.Tag}}
+{{- end}}
+		alias
+	}{
+{{- range .Payload.Files}}
+		{{.Name}}: {{.Local}},
+{{- end}}
+		alias: alias(m),
+	}
+	return newFormPayload(body, sink.files), nil
+{{- end}}

--- a/targets/golangv2/templates/resolve.tmpl
+++ b/targets/golangv2/templates/resolve.tmpl
@@ -1,0 +1,78 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	resolve_marshal writes the rewrite of a declaration that a union reaching a
+	file admits, but which holds no file of its own. It has nothing to hand over,
+	so it rewrites itself by marshalling — which for a declaration a union tells
+	apart still writes the discriminator, since its own marshaller does. A variant
+	can be admitted by two such unions at once, which is why the rewrite is
+	written here, once, where the variant is declared.
+
+	It is a shape, not an entity: any view offering Name renders through it.
+*/}}
+{{- define "resolve_marshal"}}
+func (o {{.Name}}) resolve(_ *fileSink) (json.RawMessage, error) {
+	return json.Marshal(o)
+}
+{{- end}}
+
+{{- /*
+	resolve_object writes how an object holding a file rewrites itself into the
+	JSON its owner embeds. It cannot marshal normally: a file has to leave the
+	body for a part of its own, so every such field hands its file to the sink
+	and is shadowed by the reference left behind. Everything else rides the
+	alias, which is a defined type and holds no method, so marshalling the
+	shadow never calls back into this object.
+*/}}
+{{- define "resolve_object"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Object*/}}
+func (o {{.Name}}) resolve(sink *fileSink) (json.RawMessage, error) {
+{{- range .Files}}
+{{- render .Template .}}
+{{- end}}
+	type alias {{.Name}}
+	return json.Marshal(struct {
+{{- range .Files}}
+		{{.Name}} {{.Shadow}} {{.Tag}}
+{{- end}}
+		alias
+	}{
+{{- range .Files}}
+		{{.Name}}: {{.Local}},
+{{- end}}
+		alias: alias(o),
+	})
+}
+{{- end}}
+
+{{- /*
+	resolve_discriminated_object writes the same rewrite for an object a union
+	tells apart. It repeats the discriminator its marshaller would have written,
+	because the alias the shadow rides strips that marshaller away and nothing
+	else would write it.
+*/}}
+{{- define "resolve_discriminated_object"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.DiscriminatedObject*/}}
+func (o {{.Name}}) resolve(sink *fileSink) (json.RawMessage, error) {
+{{- range .Files}}
+{{- render .Template .}}
+{{- end}}
+	type alias {{.Name}}
+	return json.Marshal(struct {
+{{- with .Discriminator}}
+		{{.Name}} {{.Type}} {{.Tag}}
+{{- end}}
+{{- range .Files}}
+		{{.Name}} {{.Shadow}} {{.Tag}}
+{{- end}}
+		alias
+	}{
+{{- with .Discriminator}}
+		{{.Name}}: {{.Value}},
+{{- end}}
+{{- range .Files}}
+		{{.Name}}: {{.Local}},
+{{- end}}
+		alias: alias(o),
+	})
+}
+{{- end}}

--- a/targets/golangv2/templates/return.tmpl
+++ b/targets/golangv2/templates/return.tmpl
@@ -1,0 +1,38 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- define "return_command"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+	return conn.Do(ctx, "{{.Wire}}", payload, new(bool))
+{{- end}}
+
+{{- define "return_plain"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+	var resp {{.Return.Value}}
+	if err := conn.Do(ctx, "{{.Wire}}", payload, &resp); err != nil {
+		{{.Return.Fail}}
+	}
+	return resp, nil
+{{- end}}
+
+{{- define "return_union"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+	var resp json.RawMessage
+	if err := conn.Do(ctx, "{{.Wire}}", payload, &resp); err != nil {
+		{{.Return.Fail}}
+	}
+	return unmarshal{{.Return.Name}}(resp)
+{{- end}}
+
+{{- define "return_union_array"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Method*/}}
+	var resp []json.RawMessage
+	if err := conn.Do(ctx, "{{.Wire}}", payload, &resp); err != nil {
+		{{.Return.Fail}}
+	}
+	result := make([]{{.Return.Name}}, len(resp))
+	for i, r := range resp {
+		v, err := unmarshal{{.Return.Name}}(r)
+		if err != nil {
+			{{.Return.Fail}}
+		}
+		result[i] = v
+	}
+	return result, nil
+{{- end}}

--- a/targets/golangv2/templates/types.tmpl
+++ b/targets/golangv2/templates/types.tmpl
@@ -1,0 +1,63 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	struct writes the type declaration shared by every object, whatever tells it
+	apart. It is a shape, not an entity: any view offering Doc, Name and Fields
+	renders through it, and no kinship between those views is implied.
+*/}}
+{{- define "struct"}}
+{{.Doc}}
+type {{.Name}} struct {
+{{- range .Fields}}
+{{- with .Doc}}
+	{{.}}
+{{- end}}
+	{{.Name}} {{.Type}} {{.Tag}}
+{{- end}}
+}
+{{- end}}
+
+{{- define "object"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Object*/}}
+{{- template "struct" .}}
+{{- if .Unions}}
+{{template "unmarshal_object" .}}
+{{- end}}
+{{- if .Files}}
+{{template "resolve_object" .}}
+{{- else if .Rewrites}}
+{{template "resolve_marshal" .}}
+{{- end}}
+{{- end}}
+
+{{- define "discriminated_object"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.DiscriminatedObject*/}}
+{{- template "struct" .}}
+
+func (o {{.Name}}) MarshalJSON() ([]byte, error) {
+	type alias {{.Name}}
+	return json.Marshal(struct {
+{{- with .Discriminator}}
+		{{.Name}} {{.Type}} {{.Tag}}
+{{- end}}
+		alias
+	}{
+{{- with .Discriminator}}
+		{{.Name}}: {{.Value}},
+{{- end}}
+		alias: alias(o),
+	})
+}
+{{- if .Unions}}
+{{template "unmarshal_object" .}}
+{{- end}}
+{{- if .Files}}
+{{template "resolve_discriminated_object" .}}
+{{- else if .Rewrites}}
+{{template "resolve_marshal" .}}
+{{- end}}
+{{- end}}
+
+{{- define "alias"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Alias*/}}
+{{.Doc}}
+type {{.Name}} {{.Type}}
+{{- end}}

--- a/targets/golangv2/templates/union.tmpl
+++ b/targets/golangv2/templates/union.tmpl
@@ -1,0 +1,78 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	A union carries a file as soon as one variant does, so the rewrite lands in
+	the interface and every variant has to answer for it — including those holding
+	no file. Their rewrite is not written here: a variant may be admitted by two
+	such unions at once, and only the variant itself can say the method once. It
+	is written where the variant is declared, driven by Rewrites.
+*/}}
+
+{{- /*
+	union writes the shell of a union and nothing else: the interface, and on
+	every variant the marker admitting it. The decoder is missing on purpose —
+	which variant a payload holds is not written anywhere the specification can
+	be read from, so the block claiming this reference writes it by hand.
+*/}}
+{{- define "union"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- $union := .Name}}
+{{.Doc}}
+//sumtype:decl
+{{if .Carrier -}}
+type {{$union}} interface {
+	resolve(sink *fileSink) (json.RawMessage, error)
+	sealed{{$union}}()
+}
+{{- else -}}
+type {{$union}} interface{ sealed{{$union}}() }
+{{- end}}
+{{range .Variants}}
+func ({{.Name}}) sealed{{$union}}() {}
+{{- end}}
+{{- end}}
+
+{{- /*
+	discriminated_union writes the shell and the decoder of a union one key tells
+	every variant apart. encoding/json cannot decode into an interface, so the
+	decoder reads that key off the payload first and hands the payload to the
+	variant the key names — the inbound mirror of the constant a variant writes
+	when it marshals itself.
+*/}}
+{{- define "discriminated_union"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.DiscriminatedUnion*/}}
+{{- $union := .Name}}
+{{.Doc}}
+//sumtype:decl
+{{if .Carrier -}}
+type {{$union}} interface {
+	resolve(sink *fileSink) (json.RawMessage, error)
+	sealed{{$union}}()
+}
+{{- else -}}
+type {{$union}} interface{ sealed{{$union}}() }
+{{- end}}
+{{range .Variants}}
+func ({{.Name}}) sealed{{$union}}() {}
+{{- end}}
+
+func unmarshal{{$union}}(data []byte) ({{$union}}, error) {
+	var mark struct {
+		Key string `json:{{.Key}}`
+	}
+	if err := json.Unmarshal(data, &mark); err != nil {
+		return nil, err
+	}
+	switch mark.Key {
+{{- range .Variants}}
+	case {{.Value}}:
+		var variant {{.Name}}
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+{{- end}}
+	default:
+		return nil, fmt.Errorf("unknown {{$union}} %q", mark.Key)
+	}
+}
+{{- end}}

--- a/targets/golangv2/templates/unmarshal.tmpl
+++ b/targets/golangv2/templates/unmarshal.tmpl
@@ -1,0 +1,50 @@
+{{/*SPDX-FileCopyrightText: 2026 Andrey Chernykh*/}}
+{{/*SPDX-License-Identifier: MIT*/}}
+
+{{- /*
+	unmarshal_object writes the decoder of an object holding a union. The shadow
+	names every union field twice — once as raw JSON at the surface, once inside
+	the embedded alias — and encoding/json fills the shallower one, so the alias
+	carries everything else and the raw JSON is dispatched afterwards. The alias
+	is a defined type and holds no method, which is what keeps the decoder from
+	calling itself.
+
+	It is a shape, not an entity: any view offering Name and Unions renders
+	through it, and no kinship between those views is implied.
+*/}}
+{{- define "unmarshal_object"}}
+func (o *{{.Name}}) UnmarshalJSON(data []byte) error {
+	type alias {{.Name}}
+	var aux struct {
+{{- range .Unions}}
+		{{.Name}} {{.Shadow}} {{.Tag}}
+{{- end}}
+		alias
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*o = {{.Name}}(aux.alias)
+{{- range .Unions}}
+	if aux.{{.Name}} != nil {
+{{- if .Array}}
+		result := make([]{{.Element}}, len(aux.{{.Name}}))
+		for i, raw := range aux.{{.Name}} {
+			v, err := unmarshal{{.Element}}(raw)
+			if err != nil {
+				return err
+			}
+			result[i] = v
+		}
+{{- else}}
+		result, err := unmarshal{{.Element}}(aux.{{.Name}})
+		if err != nil {
+			return err
+		}
+{{- end}}
+		o.{{.Name}} = result
+	}
+{{- end}}
+	return nil
+}
+{{- end}}

--- a/targets/golangv2/type.go
+++ b/targets/golangv2/type.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/primitive"
+	"github.com/andreychh/tgen/model/typebound"
+)
+
+// Type represents a Go type expression rendered from a resolved type and the
+// optionality of whatever carries it.
+type Type struct {
+	typ typebound.Type
+	opt model.Optionality
+}
+
+// NewType creates a Type from a resolved type and its optionality.
+func NewType(typ typebound.Type, opt model.Optionality) Type {
+	return Type{typ: typ, opt: opt}
+}
+
+// NewRequiredType creates a Type from a resolved type no optionality applies
+// to, such as the return of a method.
+func NewRequiredType(typ typebound.Type) Type {
+	return NewType(typ, false)
+}
+
+// Value returns the Go type expression: the name of the atom, enclosed in one
+// slice per dimension, or behind a pointer when an optional single value needs
+// one to tell an absent field from a zero one.
+func (t Type) Value() string {
+	if t.pointer() {
+		return "*" + t.Name()
+	}
+	return strings.Repeat("[]", int(t.typ.Dimensionality())) + t.Name()
+}
+
+// Name returns the Go name of the atom the type holds, without the slices or
+// the pointer enclosing it.
+func (t Type) Name() string {
+	switch atom := t.typ.Atom().(type) {
+	case typebound.Primitive:
+		return builtin(atom.Kind())
+	case typebound.Object:
+		return NewName(atom.Name()).Value()
+	case typebound.Union:
+		return NewName(atom.Name()).Value()
+	case typebound.Alias:
+		return NewName(atom.Name()).Value()
+	default:
+		panic(fmt.Sprintf("golangv2: unknown atom %T", atom))
+	}
+}
+
+// Zero returns the Go expression the type's zero value is written as: the
+// literal of a built-in, an empty composite of an object, what an alias stands
+// for, and nil for everything Go already gives a nil.
+func (t Type) Zero() string {
+	if t.pointer() || t.Array() {
+		return "nil"
+	}
+	switch atom := t.typ.Atom().(type) {
+	case typebound.Primitive:
+		return literal(atom.Kind())
+	case typebound.Object:
+		return NewName(atom.Name()).Value() + "{}"
+	case typebound.Union:
+		return "nil"
+	case typebound.Alias:
+		return NewRequiredType(atom.Under()).Zero()
+	default:
+		panic(fmt.Sprintf("golangv2: unknown atom %T", atom))
+	}
+}
+
+// Union reports whether the atom the type holds names a union.
+func (t Type) Union() bool {
+	_, union := t.typ.Atom().(typebound.Union)
+	return union
+}
+
+// Array reports whether the type encloses its atom in at least one slice.
+func (t Type) Array() bool {
+	return t.typ.Dimensionality() > 0
+}
+
+// pointer reports whether the type renders behind a pointer: only an optional
+// single value does, since a slice and a union interface already carry nil.
+func (t Type) pointer() bool {
+	if !t.opt {
+		return false
+	}
+	return !t.Array() && !t.Union()
+}
+
+// builtin returns the Go type a built-in of the documentation renders as.
+func builtin(kind primitive.Kind) string {
+	switch kind {
+	case primitive.Integer:
+		return "int64"
+	case primitive.Float:
+		return "float64"
+	case primitive.String:
+		return "string"
+	case primitive.Boolean, primitive.True:
+		return "bool"
+	default:
+		panic(fmt.Sprintf("golangv2: unknown primitive %q", kind))
+	}
+}
+
+// literal returns the Go expression the zero value of a built-in is written as.
+func literal(kind primitive.Kind) string {
+	switch kind {
+	case primitive.Integer, primitive.Float:
+		return "0"
+	case primitive.String:
+		return `""`
+	case primitive.Boolean, primitive.True:
+		return "false"
+	default:
+		panic(fmt.Sprintf("golangv2: unknown primitive %q", kind))
+	}
+}

--- a/targets/golangv2/union.go
+++ b/targets/golangv2/union.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"fmt"
+
+	ir "github.com/andreychh/tgen/model/ir/v2"
+	"github.com/andreychh/tgen/pkg/slices"
+)
+
+// Union represents the Go declaration of a union nothing tells the variants of
+// apart: the interface and the marker each variant carries. A decoder is not
+// among them. Which variant a payload holds is not written anywhere the
+// specification can be read from — one union is told apart by the shape of the
+// JSON, another by trying its variants in turn, a third is only ever sent — so
+// the decoder is written by hand, in the block claiming this reference.
+type Union struct {
+	inner ir.Union
+}
+
+// NewUnion creates a Union from the record of a union.
+func NewUnion(u ir.Union) Union {
+	return Union{inner: u}
+}
+
+// Doc returns the doc comment of the declaration, closing with a link back to
+// the section the union was read from.
+func (u Union) Doc() string {
+	return NewDefinitionDoc(u.inner.Ref, u.inner.Description).Value()
+}
+
+// Ref implements [Declaration].
+func (u Union) Ref() string {
+	return string(u.inner.Ref)
+}
+
+// Template implements [Declaration].
+func (u Union) Template() string {
+	return "union"
+}
+
+// Name returns the Go name the union declares.
+func (u Union) Name() string {
+	return NewName(u.inner.Name).Value()
+}
+
+// Carrier reports whether a file is reached through the union, which puts the
+// rewrite every variant answers for into the interface.
+func (u Union) Carrier() bool {
+	return u.inner.Carrier
+}
+
+// Variants returns the types the union stands for, in the order the
+// documentation listed them.
+func (u Union) Variants() []Variant {
+	return slices.NewMapped(u.inner.Variants, NewVariant)
+}
+
+// Variant represents the Go declaration of one variant of a union: the marker
+// tying the type it names to the interface.
+type Variant struct {
+	inner ir.Variant
+}
+
+// NewVariant creates a Variant from the record of a variant.
+func NewVariant(v ir.Variant) Variant {
+	return Variant{inner: v}
+}
+
+// Name returns the Go name of the type the variant names.
+func (v Variant) Name() string {
+	return NewName(v.inner.Name).Value()
+}
+
+// DiscriminatedUnion represents the Go declaration of a union one key tells
+// every variant of apart: the interface, the marker each variant carries, and
+// the decoder reading that key off the payload to pick one.
+type DiscriminatedUnion struct {
+	inner ir.DiscriminatedUnion
+}
+
+// NewDiscriminatedUnion creates a DiscriminatedUnion from the record of a
+// discriminated union.
+func NewDiscriminatedUnion(u ir.DiscriminatedUnion) DiscriminatedUnion {
+	return DiscriminatedUnion{inner: u}
+}
+
+// Doc returns the doc comment of the declaration, closing with a link back to
+// the section the union was read from.
+func (u DiscriminatedUnion) Doc() string {
+	return NewDefinitionDoc(u.inner.Ref, u.inner.Description).Value()
+}
+
+// Ref implements [Declaration].
+func (u DiscriminatedUnion) Ref() string {
+	return string(u.inner.Ref)
+}
+
+// Template implements [Declaration].
+func (u DiscriminatedUnion) Template() string {
+	return "discriminated_union"
+}
+
+// Name returns the Go name the union declares.
+func (u DiscriminatedUnion) Name() string {
+	return NewName(u.inner.Name).Value()
+}
+
+// Key returns the JSON key the decoder reads the variant off, quoted as a Go
+// string literal.
+func (u DiscriminatedUnion) Key() string {
+	return fmt.Sprintf("%q", u.inner.Key)
+}
+
+// Carrier reports whether a file is reached through the union, which puts the
+// rewrite every variant answers for into the interface.
+func (u DiscriminatedUnion) Carrier() bool {
+	return u.inner.Carrier
+}
+
+// Variants returns the types the union stands for, in the order the
+// documentation listed them.
+func (u DiscriminatedUnion) Variants() []DiscriminatedVariant {
+	return slices.NewMapped(u.inner.Variants, NewDiscriminatedVariant)
+}
+
+// DiscriminatedVariant represents the Go declaration of one variant of a
+// discriminated union: the marker tying the type it names to the interface, and
+// the value the decoder picks it by.
+type DiscriminatedVariant struct {
+	inner ir.DiscriminatedVariant
+}
+
+// NewDiscriminatedVariant creates a DiscriminatedVariant from the record of a
+// discriminated variant.
+func NewDiscriminatedVariant(v ir.DiscriminatedVariant) DiscriminatedVariant {
+	return DiscriminatedVariant{inner: v}
+}
+
+// Name returns the Go name of the type the variant names.
+func (v DiscriminatedVariant) Name() string {
+	return NewName(v.inner.Name).Value()
+}
+
+// Value returns the value the variant is told apart by, quoted as a Go string
+// literal.
+func (v DiscriminatedVariant) Value() string {
+	return fmt.Sprintf("%q", v.inner.Value)
+}

--- a/targets/golangv2/union_field.go
+++ b/targets/golangv2/union_field.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import (
+	"strings"
+
+	ir "github.com/andreychh/tgen/model/ir/v2"
+)
+
+// UnionField represents a field its owner has to decode by hand. Nothing but a
+// union needs one: encoding/json reaches into every other type on its own, but
+// it cannot pick which variant an interface holds, so the field is shadowed by
+// raw JSON and dispatched once the rest of the object is decoded. It is built
+// only for a field whose type names a union, and so is never asked to shadow a
+// field with nothing to shadow.
+type UnionField struct {
+	inner ir.Field
+}
+
+// NewUnionField creates a UnionField from the record of a field typed as a
+// union.
+func NewUnionField(f ir.Field) UnionField {
+	return UnionField{inner: f}
+}
+
+// Name returns the Go name of the field, which the shadow declares too.
+func (f UnionField) Name() string {
+	return NewNameFromKey(f.inner.Key).Value()
+}
+
+// Tag returns the struct tag of the shadow. It never omits the field: a shadow
+// is read and never written, so there is no encoding for omitempty to affect.
+func (f UnionField) Tag() string {
+	return NewTag(f.inner.Key, false).Value()
+}
+
+// Shadow returns the Go type holding the raw JSON of the field, enclosed in one
+// slice per dimension so it shadows the field's own shape.
+func (f UnionField) Shadow() string {
+	return strings.Repeat("[]", int(f.inner.Type.Dimensionality())) + "json.RawMessage"
+}
+
+// Element returns the Go name of the union the raw JSON is dispatched into,
+// without the slices enclosing it.
+func (f UnionField) Element() string {
+	return NewType(f.inner.Type, f.inner.Optionality).Name()
+}
+
+// Array reports whether the field holds a sequence, which is dispatched one
+// element at a time.
+func (f UnionField) Array() bool {
+	return f.inner.Type.Dimensionality() > 0
+}
+
+// UnionFields is the view of the fields one owner has to decode by hand,
+// narrowed from the fields it declares.
+type UnionFields struct {
+	fields []ir.Field
+}
+
+// NewUnionFields creates a UnionFields over the fields one owner declares.
+func NewUnionFields(fields []ir.Field) UnionFields {
+	return UnionFields{fields: fields}
+}
+
+// Value returns the fields typed as a union, in the order their owner declares
+// them. It is empty when encoding/json decodes the owner on its own, which is
+// what tells an owner needing a decoder from one that does not.
+func (f UnionFields) Value() []UnionField {
+	out := make([]UnionField, 0)
+	for _, field := range f.fields {
+		if !NewType(field.Type, field.Optionality).Union() {
+			continue
+		}
+		out = append(out, NewUnionField(field))
+	}
+	return out
+}


### PR DESCRIPTION
This PR adds `model/ir/v2`, which reads the tables of the `separated` stage as the records a target renders, `model/typebound`, the type language it binds every reference into, and `targets/golangv2`, which renders those records as `api.go` beside a hand-written `client.go`. The `go` command still runs the v1 chain — wiring it and retiring `model/spec`, `model/ir` and `targets/golang` come next.

The records come out as one page-ordered sequence rather than one sequence per kind, so `api.go` reads the way the documentation page does, and each record names the template that renders it, which is also how a `manual_<ref>` block written by hand takes a declaration over.

Part of #248