### PR TITLE
Mark the definitions tgen introduces and drop their page links

### DIFF
--- a/model/ir/v2/discriminated_object.go
+++ b/model/ir/v2/discriminated_object.go
@@ -13,7 +13,9 @@ import (
 // apart by. It stands beside [Object], not on top of it: the two partition the
 // objects the documentation names, and no object is both. Files narrows Fields
 // to those reaching a file, and is empty for an object holding none. Rewrites
-// reports the same as it does for [Object].
+// reports the same as it does for [Object]. Introduced reports that tgen
+// introduced the object rather than reading it from the documentation page,
+// which leaves it no section a target can address.
 type DiscriminatedObject struct {
 	Ref           model.Reference
 	Name          model.Name
@@ -21,6 +23,7 @@ type DiscriminatedObject struct {
 	Fields        []Field
 	Files         []FileField
 	Rewrites      bool
+	Introduced    bool
 	Discriminator Discriminator
 }
 

--- a/model/ir/v2/method.go
+++ b/model/ir/v2/method.go
@@ -16,6 +16,8 @@ import (
 // takes and the result it returns. Name is the name the endpoint is called by,
 // which is also the name a target derives its identifier from. Files narrows
 // Params to those reaching a file, and is empty for a method sending none.
+// Introduced reports that tgen introduced the method rather than reading it
+// from the documentation page, which leaves it no section a target can address.
 type Method struct {
 	Ref         model.Reference
 	Name        model.Name
@@ -23,6 +25,7 @@ type Method struct {
 	Params      []Field
 	Files       []FileField
 	Result      Result
+	Introduced  bool
 }
 
 func (Method) isDefinition() {}

--- a/model/ir/v2/object.go
+++ b/model/ir/v2/object.go
@@ -9,12 +9,14 @@ import (
 	"github.com/andreychh/tgen/model/typebound"
 )
 
-// Object is the record of a documented object, joined with the fields it owns.
-// Files narrows Fields to those reaching a file, and is empty for an object
-// holding none. Rewrites reports that a union reaching a file admits the object,
-// which obliges it to rewrite itself into JSON even when it holds no file of its
+// Object is the record of an object, joined with the fields it owns. Files
+// narrows Fields to those reaching a file, and is empty for an object holding
+// none. Rewrites reports that a union reaching a file admits the object, which
+// obliges it to rewrite itself into JSON even when it holds no file of its
 // own: a union carries a file as soon as one variant does, and every target
-// reaches the rest of them through the same rewrite.
+// reaches the rest of them through the same rewrite. Introduced reports that
+// tgen introduced the object rather than reading it from the documentation
+// page, which leaves it no section a target can address.
 type Object struct {
 	Ref         model.Reference
 	Name        model.Name
@@ -22,6 +24,7 @@ type Object struct {
 	Fields      []Field
 	Files       []FileField
 	Rewrites    bool
+	Introduced  bool
 }
 
 func (Object) isDefinition() {}

--- a/model/ir/v2/ordered.go
+++ b/model/ir/v2/ordered.go
@@ -7,29 +7,29 @@ import (
 	"cmp"
 	"slices"
 
-	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/corrected"
 )
 
 // Ordered is the definitions table read as a sequence: what the table holds
 // keyed by reference, given back in the order its source put it in.
 type Ordered struct {
-	definitions parsed.Definitions
+	definitions corrected.Definitions
 }
 
 // NewOrdered constructs an Ordered over a definitions table.
-func NewOrdered(definitions parsed.Definitions) Ordered {
+func NewOrdered(definitions corrected.Definitions) Ordered {
 	return Ordered{definitions: definitions}
 }
 
 // Value returns every definition the table holds, ordered by the position its
 // source gave it. A table iterates in no order, so ordering here is what makes
 // generated output the same on every run.
-func (o Ordered) Value() []parsed.Definition {
-	out := make([]parsed.Definition, 0, o.definitions.Count())
+func (o Ordered) Value() []corrected.Definition {
+	out := make([]corrected.Definition, 0, o.definitions.Count())
 	for _, definition := range o.definitions.All() {
 		out = append(out, definition)
 	}
-	slices.SortFunc(out, func(a, b parsed.Definition) int {
+	slices.SortFunc(out, func(a, b corrected.Definition) int {
 		return cmp.Compare(a.Position, b.Position)
 	})
 	return out

--- a/model/ir/v2/reading.go
+++ b/model/ir/v2/reading.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/andreychh/tgen/model"
-	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/pipeline/corrected"
 	"github.com/andreychh/tgen/model/pipeline/separated"
 )
 
@@ -16,12 +16,12 @@ import (
 // kind the definition is of.
 type Reading struct {
 	db         separated.Specification
-	definition parsed.Definition
+	definition corrected.Definition
 }
 
 // NewReading constructs a Reading of one definition against the database
 // holding what that definition owns.
-func NewReading(db separated.Specification, definition parsed.Definition) Reading {
+func NewReading(db separated.Specification, definition corrected.Definition) Reading {
 	return Reading{db: db, definition: definition}
 }
 
@@ -68,6 +68,7 @@ func (r Reading) object() (Object, error) {
 		Fields:      fields,
 		Files:       files,
 		Rewrites:    r.rewrites(),
+		Introduced:  r.definition.Introduced,
 	}, nil
 }
 
@@ -119,6 +120,7 @@ func (r Reading) discriminatedObject() (DiscriminatedObject, error) {
 		Fields:      fields,
 		Files:       files,
 		Rewrites:    r.rewrites(),
+		Introduced:  r.definition.Introduced,
 		Discriminator: Discriminator{
 			Key:   discriminator.Key,
 			Value: discriminator.Value,
@@ -145,6 +147,7 @@ func (r Reading) union() (Definition, error) {
 			Key:         key,
 			Variants:    discriminated,
 			Carrier:     carrier,
+			Introduced:  r.definition.Introduced,
 		}, nil
 	}
 	variants, err := NewVariants(r.db, r.definition.Ref).Value()
@@ -157,6 +160,7 @@ func (r Reading) union() (Definition, error) {
 		Description: r.definition.Description,
 		Variants:    variants,
 		Carrier:     carrier,
+		Introduced:  r.definition.Introduced,
 	}, nil
 }
 
@@ -186,6 +190,7 @@ func (r Reading) method() (Method, error) {
 		Params:      params,
 		Files:       files,
 		Result:      res,
+		Introduced:  r.definition.Introduced,
 	}, nil
 }
 

--- a/model/ir/v2/union.go
+++ b/model/ir/v2/union.go
@@ -14,6 +14,8 @@ import (
 // names, and no union is both. Carrier reports that a file is reached through
 // the union, which every variant answers for by rewriting itself into JSON —
 // something a target has to say where it declares what the union accepts.
+// Introduced reports that tgen introduced the union rather than reading it from
+// the documentation page, which leaves it no section a target can address.
 type DiscriminatedUnion struct {
 	Ref         model.Reference
 	Name        model.Name
@@ -21,6 +23,7 @@ type DiscriminatedUnion struct {
 	Key         model.Key
 	Variants    []DiscriminatedVariant
 	Carrier     bool
+	Introduced  bool
 }
 
 func (DiscriminatedUnion) isDefinition() {}
@@ -36,7 +39,9 @@ type DiscriminatedVariant struct {
 
 // Union is the record of a union no key tells the variants of apart, joined with
 // the variants it stands for. Carrier reports the same as it does for
-// [DiscriminatedUnion]. The tables say which types the union accepts and nothing
+// [DiscriminatedUnion]. Introduced reports that tgen introduced the union rather
+// than reading it from the documentation page, which leaves it no section a
+// target can address. The tables say which types the union accepts and nothing
 // about how to tell them apart, because nothing in the documentation does: one
 // union is told apart by the shape of the JSON, another by trying its variants
 // in turn, a third is only ever sent and never read. A target writes that by
@@ -47,6 +52,7 @@ type Union struct {
 	Description prose.Passage
 	Variants    []Variant
 	Carrier     bool
+	Introduced  bool
 }
 
 func (Union) isDefinition() {}

--- a/model/pipeline/attached/specification.go
+++ b/model/pipeline/attached/specification.go
@@ -26,7 +26,7 @@ type Files = pipeline.Table[model.Reference, File]
 // is marked. The definition, method, field, discriminator, variant, and alias
 // tables and the release ride through from the flattened stage unchanged.
 type Specification struct {
-	Definitions    parsed.Definitions
+	Definitions    corrected.Definitions
 	Methods        flattened.Methods
 	Fields         flattened.Fields
 	Files          Files

--- a/model/pipeline/corrected/chat_id.go
+++ b/model/pipeline/corrected/chat_id.go
@@ -59,7 +59,7 @@ func (r ChatID) Apply(spec Specification) (Specification, error) {
 // definitions returns base holding what ChatID names too: the union itself and
 // the two primitive aliases its variants stand for, neither of which the
 // documentation names. It fails when any of the three references is taken.
-func (r ChatID) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+func (r ChatID) definitions(base Definitions) (Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
 		chatIDRef,

--- a/model/pipeline/corrected/definition.go
+++ b/model/pipeline/corrected/definition.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package corrected
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// Definition is the record of anything a target renders, marked with where it
+// came from: a heading of the documentation page, or a rule of this stage. Its
+// reference, name, kind, position, and description carry over from the parsed
+// stage. Introduced reports the latter, and only the former stands at a section
+// a reference addresses: tgen chooses the reference of what it introduces, and
+// a heading of that same name, where one stands, describes something else.
+type Definition struct {
+	Ref         model.Reference
+	Name        model.Name
+	Kind        model.DefinitionKind
+	Position    model.Position
+	Description prose.Passage
+	Introduced  bool
+}
+
+// DefinitionMapping maps a parsed definition into a corrected one, marking it
+// as the documentation's own. What this stage introduces is marked by the rule
+// introducing it.
+type DefinitionMapping struct{}
+
+// NewDefinitionMapping constructs a DefinitionMapping.
+func NewDefinitionMapping() DefinitionMapping {
+	return DefinitionMapping{}
+}
+
+// Apply implements [pipeline.Mapping]. It never fails.
+func (m DefinitionMapping) Apply(definition parsed.Definition) (Definition, error) {
+	return Definition{
+		Ref:         definition.Ref,
+		Name:        definition.Name,
+		Kind:        definition.Kind,
+		Position:    definition.Position,
+		Description: definition.Description,
+		Introduced:  false,
+	}, nil
+}

--- a/model/pipeline/corrected/definition_table.go
+++ b/model/pipeline/corrected/definition_table.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/andreychh/tgen/model"
 	"github.com/andreychh/tgen/model/pipeline"
-	"github.com/andreychh/tgen/model/pipeline/parsed"
 	"github.com/andreychh/tgen/model/prose"
 )
 
@@ -18,22 +17,22 @@ import (
 // states what it introduces and in which order, never a position. Its zero
 // value is not usable; construct one with [NewDefinitionTable].
 type DefinitionTable struct {
-	base  parsed.Definitions
-	added pipeline.MapTable[model.Reference, parsed.Definition]
+	base  Definitions
+	added pipeline.MapTable[model.Reference, Definition]
 }
 
 // NewDefinitionTable constructs a DefinitionTable over the definitions base
 // already holds.
-func NewDefinitionTable(base parsed.Definitions) DefinitionTable {
+func NewDefinitionTable(base Definitions) DefinitionTable {
 	return DefinitionTable{
 		base:  base,
-		added: pipeline.NewMapTable[model.Reference, parsed.Definition](),
+		added: pipeline.NewMapTable[model.Reference, Definition](),
 	}
 }
 
-// Insert admits a definition tgen introduces, at the place after every
-// definition the table already holds. It fails when ref already names a
-// definition, since a reference names at most one whatever its kind.
+// Insert admits a definition tgen introduces, marked as such, at the place
+// after every definition the table already holds. It fails when ref already
+// names a definition, since a reference names at most one whatever its kind.
 func (t DefinitionTable) Insert(
 	ref model.Reference,
 	name model.Name,
@@ -43,17 +42,18 @@ func (t DefinitionTable) Insert(
 	if _, exists := t.Lookup(ref); exists {
 		return fmt.Errorf("%s already names a definition", ref)
 	}
-	t.added.Insert(ref, parsed.Definition{
+	t.added.Insert(ref, Definition{
 		Ref:         ref,
 		Name:        name,
 		Kind:        kind,
 		Position:    t.place(),
 		Description: description,
+		Introduced:  true,
 	})
 	return nil
 }
 
-func (t DefinitionTable) Lookup(ref model.Reference) (parsed.Definition, bool) {
+func (t DefinitionTable) Lookup(ref model.Reference) (Definition, bool) {
 	if definition, exists := t.added.Lookup(ref); exists {
 		return definition, true
 	}
@@ -64,8 +64,8 @@ func (t DefinitionTable) Count() int {
 	return t.base.Count() + t.added.Count()
 }
 
-func (t DefinitionTable) All() iter.Seq2[model.Reference, parsed.Definition] {
-	return func(yield func(model.Reference, parsed.Definition) bool) {
+func (t DefinitionTable) All() iter.Seq2[model.Reference, Definition] {
+	return func(yield func(model.Reference, Definition) bool) {
 		for ref, definition := range t.base.All() {
 			if !yield(ref, definition) {
 				return

--- a/model/pipeline/corrected/input_file.go
+++ b/model/pipeline/corrected/input_file.go
@@ -68,7 +68,7 @@ func (r InputFile) Apply(spec Specification) (Specification, error) {
 // object owns no field — what it holds, the bytes to send and the name to send
 // them under, has no shape shared across targets, so each target spells it
 // itself. It fails when any of the three references is taken.
-func (r InputFile) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+func (r InputFile) definitions(base Definitions) (Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
 		InputFileRef,
@@ -139,7 +139,7 @@ type inputFileFilter struct{}
 
 // Apply implements [pipeline.Filter]. It reports whether definition belongs in
 // the filtered result: false when ref is inputfile.
-func (inputFileFilter) Apply(ref model.Reference, definition parsed.Definition) bool {
+func (inputFileFilter) Apply(ref model.Reference, definition Definition) bool {
 	return ref != InputFileRef
 }
 

--- a/model/pipeline/corrected/input_media_group.go
+++ b/model/pipeline/corrected/input_media_group.go
@@ -54,7 +54,7 @@ func (r InputMediaGroup) Apply(spec Specification) (Specification, error) {
 // definitions returns base holding what InputMediaGroup names too: the union
 // itself. Its variants are documented objects and name themselves. It fails
 // when the reference is taken.
-func (r InputMediaGroup) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+func (r InputMediaGroup) definitions(base Definitions) (Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
 		inputMediaGroupRef,

--- a/model/pipeline/corrected/input_rich_media.go
+++ b/model/pipeline/corrected/input_rich_media.go
@@ -57,7 +57,7 @@ func (r InputRichMedia) Apply(spec Specification) (Specification, error) {
 // definitions returns base holding what InputRichMedia names too: the union
 // itself. Its variants are documented objects and name themselves. It fails
 // when the reference is taken.
-func (r InputRichMedia) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+func (r InputRichMedia) definitions(base Definitions) (Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
 		inputRichMediaRef,

--- a/model/pipeline/corrected/maybe_message.go
+++ b/model/pipeline/corrected/maybe_message.go
@@ -60,7 +60,7 @@ func (r MaybeMessage) Apply(spec Specification) (Specification, error) {
 // itself and the True alias its variant stands for, which the documentation
 // writes as a bare keyword rather than a named type. It fails when either
 // reference is taken.
-func (r MaybeMessage) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+func (r MaybeMessage) definitions(base Definitions) (Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
 		maybeMessageRef,

--- a/model/pipeline/corrected/reply_markup.go
+++ b/model/pipeline/corrected/reply_markup.go
@@ -56,7 +56,7 @@ func (r ReplyMarkup) Apply(spec Specification) (Specification, error) {
 // definitions returns base holding what ReplyMarkup names too: the union
 // itself. Its variants are documented objects and name themselves. It fails
 // when the reference is taken.
-func (r ReplyMarkup) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+func (r ReplyMarkup) definitions(base Definitions) (Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
 		replyMarkupRef,

--- a/model/pipeline/corrected/rich_text.go
+++ b/model/pipeline/corrected/rich_text.go
@@ -55,7 +55,7 @@ func (r RichText) Apply(spec Specification) (Specification, error) {
 // definitions returns base holding what RichText names too: the two variants
 // the documentation writes as prose rather than as list items. It fails when
 // either reference is taken.
-func (r RichText) definitions(base parsed.Definitions) (parsed.Definitions, error) {
+func (r RichText) definitions(base Definitions) (Definitions, error) {
 	out := NewDefinitionTable(base)
 	err := out.Insert(
 		richTextPlainRef,

--- a/model/pipeline/corrected/specification.go
+++ b/model/pipeline/corrected/specification.go
@@ -9,6 +9,10 @@
 // A definition tgen introduces has no place on the page, so it stands after
 // every definition the page provides, in the order the rules run. Positions
 // downstream of this stage therefore no longer index the page's headings.
+//
+// Every definition carries from here whether tgen introduced it. This is the
+// last stage that can tell: downstream, a reference tgen chose is
+// indistinguishable from one the page provides.
 package corrected
 
 import (
@@ -22,6 +26,10 @@ import (
 	"github.com/andreychh/tgen/model/pipeline/typed"
 )
 
+// Definitions is the table of everything a target renders, keyed by reference,
+// each marked with whether tgen introduced it.
+type Definitions = pipeline.Table[model.Reference, Definition]
+
 // Aliases is the table of what each alias has of its own, keyed by reference.
 // Only a definition of alias kind has a record here.
 type Aliases = pipeline.Table[model.Reference, Alias]
@@ -31,7 +39,7 @@ type Aliases = pipeline.Table[model.Reference, Alias]
 // the documentation does not name, and redirect matching field or method
 // types to them.
 type Specification struct {
-	Definitions    parsed.Definitions
+	Definitions    Definitions
 	Methods        resolved.Methods
 	Fields         typed.Fields
 	Discriminators classified.Discriminators
@@ -60,13 +68,18 @@ func NewPass(spec resolved.Specification) Pass {
 	return Pass{spec: spec}
 }
 
-// Specification returns the corrected specification, applying every rule tgen
-// introduces, in order. No rule matches a type shape another rule produces, so
-// the order is not significant; a rule added here must keep that true. It
-// fails when any rule fails.
+// Specification returns the corrected specification: every definition the
+// resolved stage provides marked as the documentation's own, then every rule
+// tgen introduces applied in order. No rule matches a type shape another rule
+// produces, so the order is not significant; a rule added here must keep that
+// true. It fails when any rule fails.
 func (p Pass) Specification() (Specification, error) {
+	definitions, err := pipeline.NewMappedTable(p.spec.Definitions, NewDefinitionMapping()).Apply()
+	if err != nil {
+		return Specification{}, fmt.Errorf("marking definitions: %w", err)
+	}
 	spec := Specification{
-		Definitions:    p.spec.Definitions,
+		Definitions:    definitions,
 		Methods:        p.spec.Methods,
 		Fields:         p.spec.Fields,
 		Discriminators: p.spec.Discriminators,

--- a/model/pipeline/flattened/specification.go
+++ b/model/pipeline/flattened/specification.go
@@ -30,7 +30,7 @@ type Aliases = pipeline.Table[model.Reference, Alias]
 // definition, discriminator, and variant tables and the release ride through
 // from the corrected stage unchanged.
 type Specification struct {
-	Definitions    parsed.Definitions
+	Definitions    corrected.Definitions
 	Methods        Methods
 	Fields         Fields
 	Discriminators classified.Discriminators

--- a/model/pipeline/separated/specification.go
+++ b/model/pipeline/separated/specification.go
@@ -12,6 +12,7 @@ import (
 	"github.com/andreychh/tgen/model/pipeline"
 	"github.com/andreychh/tgen/model/pipeline/attached"
 	"github.com/andreychh/tgen/model/pipeline/classified"
+	"github.com/andreychh/tgen/model/pipeline/corrected"
 	"github.com/andreychh/tgen/model/pipeline/flattened"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 )
@@ -23,7 +24,7 @@ type Methods = pipeline.Table[model.Reference, Method]
 // the method signals. The definition, field, discriminator, variant, alias, and
 // file tables and the release ride through from the attached stage unchanged.
 type Specification struct {
-	Definitions    parsed.Definitions
+	Definitions    corrected.Definitions
 	Methods        Methods
 	Fields         flattened.Fields
 	Files          attached.Files

--- a/stands/gov2/api/api.go
+++ b/stands/gov2/api/api.go
@@ -21034,8 +21034,6 @@ type GameHighScore struct {
 }
 
 // ChatId represents a chat identifier, either a numeric ID or a username.
-//
-// See https://core.telegram.org/bots/api#chatid
 //sumtype:decl
 type ChatID interface{ sealedChatID() }
 
@@ -21061,8 +21059,6 @@ type ID int64
 type Username string
 
 // ReplyMarkup represents a reply markup attached to a message.
-//
-// See https://core.telegram.org/bots/api#replymarkup
 //sumtype:decl
 type ReplyMarkup interface{ sealedReplyMarkup() }
 
@@ -21072,8 +21068,6 @@ func (ReplyKeyboardRemove) sealedReplyMarkup() {}
 func (ForceReply) sealedReplyMarkup() {}
 
 // InputMediaGroup represents a media element in a media group.
-//
-// See https://core.telegram.org/bots/api#inputmediagroup
 //sumtype:decl
 type InputMediaGroup interface {
 	resolve(sink *fileSink) (json.RawMessage, error)
@@ -21130,8 +21124,6 @@ func unmarshalInputMediaGroup(data []byte) (InputMediaGroup, error) {
 }
 
 // InputRichMedia represents a media element embedded in a rich message.
-//
-// See https://core.telegram.org/bots/api#inputrichmedia
 //sumtype:decl
 type InputRichMedia interface {
 	resolve(sink *fileSink) (json.RawMessage, error)
@@ -21188,8 +21180,6 @@ func unmarshalInputRichMedia(data []byte) (InputRichMedia, error) {
 }
 
 // InputFile represents a file to send, either by file ID or by uploading.
-//
-// See https://core.telegram.org/bots/api#inputfile
 //sumtype:decl
 type InputFile interface {
 	place(sink *fileSink, key string) *string
@@ -21222,8 +21212,6 @@ func (f FileID) attach(_ *fileSink) string {
 
 // Upload represents a file sent with the request, carrying the bytes to send
 // and the name to send them under.
-//
-// See https://core.telegram.org/bots/api#upload
 type Upload struct {
 	Name   string
 	Reader io.Reader
@@ -21247,8 +21235,6 @@ func (u Upload) name() string {
 
 // MaybeMessage represents a method return value that is either an edited
 // Message or True for inline messages.
-//
-// See https://core.telegram.org/bots/api#maybemessage
 //sumtype:decl
 type MaybeMessage interface{ sealedMaybeMessage() }
 

--- a/targets/golangv2/definition_doc.go
+++ b/targets/golangv2/definition_doc.go
@@ -11,21 +11,28 @@ import (
 	"github.com/andreychh/tgen/targets"
 )
 
-// DefinitionDoc represents the doc comment of a documented definition: the
-// prose of its section followed by a link back to that section.
+// DefinitionDoc represents the doc comment of a definition: the prose
+// describing it, closed by a link to the section of the documentation page it
+// stands at, where it stands at one.
 type DefinitionDoc struct {
-	ref     model.Reference
-	passage prose.Passage
+	ref        model.Reference
+	passage    prose.Passage
+	introduced bool
 }
 
 // NewDefinitionDoc creates a DefinitionDoc for the definition at ref from the
-// prose of its section.
-func NewDefinitionDoc(ref model.Reference, passage prose.Passage) DefinitionDoc {
-	return DefinitionDoc{ref: ref, passage: passage}
+// prose describing it and whether tgen introduced it.
+func NewDefinitionDoc(ref model.Reference, passage prose.Passage, introduced bool) DefinitionDoc {
+	return DefinitionDoc{ref: ref, passage: passage, introduced: introduced}
 }
 
-// Value returns the doc comment, closing with the URL of the section.
+// Value returns the doc comment, closing with the URL of the section unless
+// tgen introduced the definition, which the page never named and so gave no
+// section to address.
 func (d DefinitionDoc) Value() string {
+	if d.introduced {
+		return NewTypeGodoc(d.passage).Value()
+	}
 	return NewTypeGodoc(
 		prose.NewPassage(append(
 			slices.Clone(d.passage.Blocks()),

--- a/targets/golangv2/discriminated_object.go
+++ b/targets/golangv2/discriminated_object.go
@@ -25,7 +25,7 @@ func NewDiscriminatedObject(o ir.DiscriminatedObject) DiscriminatedObject {
 // Doc returns the doc comment of the declaration, closing with a link back to
 // the section the object was read from.
 func (o DiscriminatedObject) Doc() string {
-	return NewDefinitionDoc(o.inner.Ref, o.inner.Description).Value()
+	return NewDefinitionDoc(o.inner.Ref, o.inner.Description, o.inner.Introduced).Value()
 }
 
 // Ref implements [Declaration].

--- a/targets/golangv2/method.go
+++ b/targets/golangv2/method.go
@@ -23,7 +23,7 @@ func NewMethod(m ir.Method) Method {
 // Doc returns the doc comment of the declaration, closing with a link back to
 // the section the method was read from.
 func (m Method) Doc() string {
-	return NewDefinitionDoc(m.inner.Ref, m.inner.Description).Value()
+	return NewDefinitionDoc(m.inner.Ref, m.inner.Description, m.inner.Introduced).Value()
 }
 
 // Ref implements [Declaration].

--- a/targets/golangv2/object.go
+++ b/targets/golangv2/object.go
@@ -21,7 +21,7 @@ func NewObject(o ir.Object) Object {
 // Doc returns the doc comment of the declaration, closing with a link back to
 // the section the object was read from.
 func (o Object) Doc() string {
-	return NewDefinitionDoc(o.inner.Ref, o.inner.Description).Value()
+	return NewDefinitionDoc(o.inner.Ref, o.inner.Description, o.inner.Introduced).Value()
 }
 
 // Ref implements [Declaration].

--- a/targets/golangv2/union.go
+++ b/targets/golangv2/union.go
@@ -28,7 +28,7 @@ func NewUnion(u ir.Union) Union {
 // Doc returns the doc comment of the declaration, closing with a link back to
 // the section the union was read from.
 func (u Union) Doc() string {
-	return NewDefinitionDoc(u.inner.Ref, u.inner.Description).Value()
+	return NewDefinitionDoc(u.inner.Ref, u.inner.Description, u.inner.Introduced).Value()
 }
 
 // Ref implements [Declaration].
@@ -90,7 +90,7 @@ func NewDiscriminatedUnion(u ir.DiscriminatedUnion) DiscriminatedUnion {
 // Doc returns the doc comment of the declaration, closing with a link back to
 // the section the union was read from.
 func (u DiscriminatedUnion) Doc() string {
-	return NewDefinitionDoc(u.inner.Ref, u.inner.Description).Value()
+	return NewDefinitionDoc(u.inner.Ref, u.inner.Description, u.inner.Introduced).Value()
 }
 
 // Ref implements [Declaration].


### PR DESCRIPTION
This PR adds an `Introduced` flag to the definition record, set where each definition is born, and stops `DefinitionDoc` from closing a doc comment with a page link when the flag is set.

The flag is set in `corrected` rather than `parsed`, which redefines `Definition` there the way the pipeline already redefines `Field` at every stage that adds knowledge to it — that is why `flattened`, `attached` and `separated` retype their `Definitions` table.

Closes #252