### PR TITLE
Compute `Direction` for every definition and drop unreachable codecs

### DIFF
--- a/cli/pipeline.go
+++ b/cli/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/andreychh/tgen/model/pipeline/attached"
 	"github.com/andreychh/tgen/model/pipeline/classified"
 	"github.com/andreychh/tgen/model/pipeline/corrected"
+	"github.com/andreychh/tgen/model/pipeline/directed"
 	"github.com/andreychh/tgen/model/pipeline/flattened"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 	"github.com/andreychh/tgen/model/pipeline/resolved"
@@ -65,7 +66,11 @@ func (p Pipeline) Specification() (separated.Specification, error) {
 	if err != nil {
 		return separated.Specification{}, fmt.Errorf("attaching files: %w", err)
 	}
-	spec, err := separated.NewPass(files).Specification()
+	directions, err := directed.NewPass(files).Specification()
+	if err != nil {
+		return separated.Specification{}, fmt.Errorf("directing definitions: %w", err)
+	}
+	spec, err := separated.NewPass(directions).Specification()
 	if err != nil {
 		return separated.Specification{}, fmt.Errorf("separating returns: %w", err)
 	}

--- a/model/ir/v2/alias.go
+++ b/model/ir/v2/alias.go
@@ -10,12 +10,16 @@ import (
 )
 
 // Alias is the record of a name tgen gives a type the documentation leaves
-// unnamed, joined with the type that name stands for.
+// unnamed, joined with the type that name stands for. Direction is which way
+// the alias travels between a client and the API; the declaration it stands for
+// is the same either way, since an alias is another name for a type that
+// already answers for its own encoding.
 type Alias struct {
 	Ref         model.Reference
 	Name        model.Name
 	Type        typebound.Type
 	Description prose.Passage
+	Direction   model.Direction
 }
 
 func (Alias) isDefinition() {}

--- a/model/ir/v2/discriminated_object.go
+++ b/model/ir/v2/discriminated_object.go
@@ -13,7 +13,10 @@ import (
 // apart by. It stands beside [Object], not on top of it: the two partition the
 // objects the documentation names, and no object is both. Files narrows Fields
 // to those reaching a file, and is empty for an object holding none. Rewrites
-// reports the same as it does for [Object]. Introduced reports that tgen
+// reports the same as it does for [Object]. Direction is which way the object
+// travels between a client and the API: one no request carries is never
+// encoded, so the fixed value telling it apart never has to be written at all,
+// and one no response carries is never decoded. Introduced reports that tgen
 // introduced the object rather than reading it from the documentation page,
 // which leaves it no section a target can address.
 type DiscriminatedObject struct {
@@ -23,6 +26,7 @@ type DiscriminatedObject struct {
 	Fields        []Field
 	Files         []FileField
 	Rewrites      bool
+	Direction     model.Direction
 	Introduced    bool
 	Discriminator Discriminator
 }

--- a/model/ir/v2/object.go
+++ b/model/ir/v2/object.go
@@ -14,9 +14,12 @@ import (
 // none. Rewrites reports that a union reaching a file admits the object, which
 // obliges it to rewrite itself into JSON even when it holds no file of its
 // own: a union carries a file as soon as one variant does, and every target
-// reaches the rest of them through the same rewrite. Introduced reports that
-// tgen introduced the object rather than reading it from the documentation
-// page, which leaves it no section a target can address.
+// reaches the rest of them through the same rewrite. Direction is which way the
+// object travels between a client and the API: one no request carries needs
+// nothing written to encode it, and one no response carries needs nothing
+// written to decode it. Introduced reports that tgen introduced the object
+// rather than reading it from the documentation page, which leaves it no
+// section a target can address.
 type Object struct {
 	Ref         model.Reference
 	Name        model.Name
@@ -24,6 +27,7 @@ type Object struct {
 	Fields      []Field
 	Files       []FileField
 	Rewrites    bool
+	Direction   model.Direction
 	Introduced  bool
 }
 

--- a/model/ir/v2/reading.go
+++ b/model/ir/v2/reading.go
@@ -61,6 +61,10 @@ func (r Reading) object() (Object, error) {
 	if err != nil {
 		return Object{}, fmt.Errorf("joining object %s: %w", r.definition.Ref, err)
 	}
+	direction, err := r.direction()
+	if err != nil {
+		return Object{}, fmt.Errorf("joining object %s: %w", r.definition.Ref, err)
+	}
 	return Object{
 		Ref:         r.definition.Ref,
 		Name:        r.definition.Name,
@@ -68,8 +72,20 @@ func (r Reading) object() (Object, error) {
 		Fields:      fields,
 		Files:       files,
 		Rewrites:    r.rewrites(),
+		Direction:   direction,
 		Introduced:  r.definition.Introduced,
 	}, nil
+}
+
+// direction returns which way the definition travels. It fails when the
+// specification names no direction for it, which only a method is left without,
+// so failing here means a method was read as something it is not.
+func (r Reading) direction() (model.Direction, error) {
+	direction, found := r.db.Directions.Lookup(r.definition.Ref)
+	if !found {
+		return "", fmt.Errorf("%s travels nowhere", r.definition.Ref)
+	}
+	return direction, nil
 }
 
 // rewrites reports whether a union reaching a file admits the definition, which
@@ -113,6 +129,14 @@ func (r Reading) discriminatedObject() (DiscriminatedObject, error) {
 			err,
 		)
 	}
+	direction, err := r.direction()
+	if err != nil {
+		return DiscriminatedObject{}, fmt.Errorf(
+			"joining discriminated object %s: %w",
+			r.definition.Ref,
+			err,
+		)
+	}
 	return DiscriminatedObject{
 		Ref:         r.definition.Ref,
 		Name:        r.definition.Name,
@@ -120,6 +144,7 @@ func (r Reading) discriminatedObject() (DiscriminatedObject, error) {
 		Fields:      fields,
 		Files:       files,
 		Rewrites:    r.rewrites(),
+		Direction:   direction,
 		Introduced:  r.definition.Introduced,
 		Discriminator: Discriminator{
 			Key:   discriminator.Key,
@@ -135,6 +160,10 @@ func (r Reading) discriminatedObject() (DiscriminatedObject, error) {
 func (r Reading) union() (Definition, error) {
 	mark, reaches := r.db.Files.Lookup(r.definition.Ref)
 	carrier := reaches && mark.Kind == model.FileKindCarrier
+	direction, err := r.direction()
+	if err != nil {
+		return nil, fmt.Errorf("joining union %s: %w", r.definition.Ref, err)
+	}
 	key, discriminated, err := NewVariants(r.db, r.definition.Ref).Discriminated()
 	if err != nil {
 		return nil, fmt.Errorf("joining union %s: %w", r.definition.Ref, err)
@@ -147,6 +176,7 @@ func (r Reading) union() (Definition, error) {
 			Key:         key,
 			Variants:    discriminated,
 			Carrier:     carrier,
+			Direction:   direction,
 			Introduced:  r.definition.Introduced,
 		}, nil
 	}
@@ -160,6 +190,7 @@ func (r Reading) union() (Definition, error) {
 		Description: r.definition.Description,
 		Variants:    variants,
 		Carrier:     carrier,
+		Direction:   direction,
 		Introduced:  r.definition.Introduced,
 	}, nil
 }
@@ -205,10 +236,15 @@ func (r Reading) alias() (Alias, error) {
 	if err != nil {
 		return Alias{}, fmt.Errorf("resolving alias %s: %w", r.definition.Ref, err)
 	}
+	direction, err := r.direction()
+	if err != nil {
+		return Alias{}, fmt.Errorf("joining alias %s: %w", r.definition.Ref, err)
+	}
 	return Alias{
 		Ref:         r.definition.Ref,
 		Name:        r.definition.Name,
 		Type:        typ,
 		Description: r.definition.Description,
+		Direction:   direction,
 	}, nil
 }

--- a/model/ir/v2/union.go
+++ b/model/ir/v2/union.go
@@ -14,8 +14,11 @@ import (
 // names, and no union is both. Carrier reports that a file is reached through
 // the union, which every variant answers for by rewriting itself into JSON —
 // something a target has to say where it declares what the union accepts.
-// Introduced reports that tgen introduced the union rather than reading it from
-// the documentation page, which leaves it no section a target can address.
+// Direction is which way the union travels between a client and the API: one no
+// response carries is never read, so it needs no decoder however plainly the key
+// tells its variants apart. Introduced reports that tgen introduced the union
+// rather than reading it from the documentation page, which leaves it no section
+// a target can address.
 type DiscriminatedUnion struct {
 	Ref         model.Reference
 	Name        model.Name
@@ -23,6 +26,7 @@ type DiscriminatedUnion struct {
 	Key         model.Key
 	Variants    []DiscriminatedVariant
 	Carrier     bool
+	Direction   model.Direction
 	Introduced  bool
 }
 
@@ -39,19 +43,22 @@ type DiscriminatedVariant struct {
 
 // Union is the record of a union no key tells the variants of apart, joined with
 // the variants it stands for. Carrier reports the same as it does for
-// [DiscriminatedUnion]. Introduced reports that tgen introduced the union rather
-// than reading it from the documentation page, which leaves it no section a
-// target can address. The tables say which types the union accepts and nothing
-// about how to tell them apart, because nothing in the documentation does: one
-// union is told apart by the shape of the JSON, another by trying its variants
-// in turn, a third is only ever sent and never read. A target writes that by
-// hand.
+// [DiscriminatedUnion]. Direction is which way the union travels between a
+// client and the API, which says whether a decoder written by hand is needed at
+// all: one no response carries is never read. Introduced reports that tgen
+// introduced the union rather than reading it from the documentation page, which
+// leaves it no section a target can address. The tables say which types the
+// union accepts and nothing about how to tell them apart, because nothing in the
+// documentation does: one union is told apart by the shape of the JSON, another
+// by trying its variants in turn, a third is only ever sent and never read. A
+// target writes that by hand.
 type Union struct {
 	Ref         model.Reference
 	Name        model.Name
 	Description prose.Passage
 	Variants    []Variant
 	Carrier     bool
+	Direction   model.Direction
 	Introduced  bool
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -39,6 +39,25 @@ const (
 	FileKindCarrier FileKind = "carrier"
 )
 
+// Direction is where a definition travels between a client and the API,
+// telling a target whether the value has to write itself into a request, read
+// itself out of a response, or answer for both. It classifies what is carried
+// and not what carries it: a method is an operation rather than cargo, and what
+// travels is the parameters it takes and the value it hands back.
+type Direction string
+
+const (
+	// DirectionOutbound marks a definition only a request carries, which writes
+	// itself and is never read back.
+	DirectionOutbound Direction = "outbound"
+	// DirectionInbound marks a definition only a response carries, which is read
+	// and never written.
+	DirectionInbound Direction = "inbound"
+	// DirectionBidirectional marks a definition a request and a response both
+	// carry, which does either.
+	DirectionBidirectional Direction = "bidirectional"
+)
+
 type Optionality bool
 
 type Key string

--- a/model/pipeline/directed/reach.go
+++ b/model/pipeline/directed/reach.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package directed
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+)
+
+// Reach is how far the spread has got to one definition. It is the state of a
+// traversal and not a property of what is traversed, which is why it holds a
+// fourth case [model.Direction] has no room for: a definition may be reached by
+// nothing yet, and while the spread runs most of them are.
+type Reach string
+
+const (
+	// ReachNone marks a definition nothing has reached. It is the zero value on
+	// purpose, so a reference absent from the spread reads as unreached without
+	// being asked for separately.
+	ReachNone Reach = ""
+	// ReachOutbound marks a definition reached only as something a request
+	// carries.
+	ReachOutbound Reach = "outbound"
+	// ReachInbound marks a definition reached only as something a response
+	// carries.
+	ReachInbound Reach = "inbound"
+	// ReachBoth marks a definition reached as both.
+	ReachBoth Reach = "both"
+)
+
+// Merged returns what is known of a definition reached both as r and as other.
+// The answer is never less than either, which is what settles the spread: a
+// reach rises twice at most, from [ReachNone] to one direction and from there
+// to [ReachBoth].
+func (r Reach) Merged(other Reach) Reach {
+	switch {
+	case r == other:
+		return r
+	case r == ReachNone:
+		return other
+	case other == ReachNone:
+		return r
+	default:
+		return ReachBoth
+	}
+}
+
+// Direction returns the direction the reach amounts to. It fails when nothing
+// reached the definition, a definition no request and no response carries being
+// a gap in the specification rather than a direction of its own, and when the
+// reach is one no spread produces.
+func (r Reach) Direction() (model.Direction, error) {
+	switch r {
+	case ReachOutbound:
+		return model.DirectionOutbound, nil
+	case ReachInbound:
+		return model.DirectionInbound, nil
+	case ReachBoth:
+		return model.DirectionBidirectional, nil
+	case ReachNone:
+		return "", errors.New("reached by nothing")
+	default:
+		return "", fmt.Errorf("unknown reach %q", r)
+	}
+}
+
+// Reaches is the state of the spread: how far every definition has been reached
+// so far, keyed by reference. It is the one thing a spread mutates, and it
+// mutates only upwards. Its zero value is not usable; construct one with
+// [NewReaches]. A Reaches is not safe for concurrent use.
+type Reaches struct {
+	inner map[model.Reference]Reach
+}
+
+// NewReaches constructs an empty Reaches.
+func NewReaches() Reaches {
+	return Reaches{inner: make(map[model.Reference]Reach)}
+}
+
+// Lookup returns how far ref has been reached, [ReachNone] for a reference
+// nothing has reached yet.
+func (r Reaches) Lookup(ref model.Reference) Reach {
+	return r.inner[ref]
+}
+
+// Merge records that ref is reached as reach besides however it was reached
+// before, and reports whether that raised what is known of it. Merging
+// [ReachNone] raises nothing and records nothing, which is what lets an edge
+// leading out of an unreached definition be followed without a test of its own.
+func (r Reaches) Merge(ref model.Reference, reach Reach) bool {
+	known := r.inner[ref]
+	merged := known.Merged(reach)
+	if merged == known {
+		return false
+	}
+	r.inner[ref] = merged
+	return true
+}

--- a/model/pipeline/directed/rule.go
+++ b/model/pipeline/directed/rule.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package directed
+
+import (
+	"iter"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/flattened"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+	"github.com/andreychh/tgen/model/typeform"
+)
+
+// Rule is one relation of the specification read as edges of the graph a
+// direction travels along. An edge says one thing and only that: the two
+// travel together, so whatever reaches the source reaches the target
+// unchanged. That is why a rule names no direction of its own — it knows which
+// definitions go together, and what they carry is decided where the marks are
+// kept. A relation obliged to produce a direction instead of passing one along
+// is no rule at all, and enters the spread as a seed.
+type Rule interface {
+	// Edges returns every pair the relation puts in the graph, the source first
+	// and the target second, in no particular order. A relation reaching a
+	// primitive puts no pair in the graph, a primitive being no definition an
+	// edge could lead to.
+	Edges() iter.Seq2[model.Reference, model.Reference]
+}
+
+// FieldRule is the [Rule] of ownership: an object travels whole, so the type of
+// a field goes wherever the definition owning that field goes. Dimensionality
+// does not matter, since an array travels with what it holds. A field typed as
+// a primitive puts no edge in the graph, a primitive being no definition that
+// could travel anywhere.
+type FieldRule struct {
+	fields flattened.Fields
+}
+
+// NewFieldRule constructs a FieldRule over a table of fields.
+func NewFieldRule(fields flattened.Fields) FieldRule {
+	return FieldRule{fields: fields}
+}
+
+// Edges implements [Rule].
+func (r FieldRule) Edges() iter.Seq2[model.Reference, model.Reference] {
+	return func(yield func(model.Reference, model.Reference) bool) {
+		for key, field := range r.fields.All() {
+			named, ok := field.Type.Atom().(typeform.Named)
+			if !ok {
+				continue
+			}
+			if !yield(key.Owner, named.Ref()) {
+				return
+			}
+		}
+	}
+}
+
+// VariantRule is the [Rule] of alternation: a union travels as whichever
+// variant it holds, so a variant goes wherever the union admitting it goes. A
+// union owns no field, so this is the only edge leading out of one.
+type VariantRule struct {
+	variants parsed.Variants
+}
+
+// NewVariantRule constructs a VariantRule over a table of variants.
+func NewVariantRule(variants parsed.Variants) VariantRule {
+	return VariantRule{variants: variants}
+}
+
+// Edges implements [Rule].
+func (r VariantRule) Edges() iter.Seq2[model.Reference, model.Reference] {
+	return func(yield func(model.Reference, model.Reference) bool) {
+		for key := range r.variants.All() {
+			if !yield(key.Owner, key.Ref) {
+				return
+			}
+		}
+	}
+}
+
+// AliasRule is the [Rule] of standing for: an alias is another name and nothing
+// besides, so the type it stands for goes wherever the alias goes. An alias
+// standing for a primitive puts no edge in the graph, for the same reason a
+// field typed as one does not.
+type AliasRule struct {
+	aliases flattened.Aliases
+}
+
+// NewAliasRule constructs an AliasRule over a table of aliases.
+func NewAliasRule(aliases flattened.Aliases) AliasRule {
+	return AliasRule{aliases: aliases}
+}
+
+// Edges implements [Rule].
+func (r AliasRule) Edges() iter.Seq2[model.Reference, model.Reference] {
+	return func(yield func(model.Reference, model.Reference) bool) {
+		for ref, alias := range r.aliases.All() {
+			named, ok := alias.Type.Atom().(typeform.Named)
+			if !ok {
+				continue
+			}
+			if !yield(ref, named.Ref()) {
+				return
+			}
+		}
+	}
+}

--- a/model/pipeline/directed/seeding.go
+++ b/model/pipeline/directed/seeding.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package directed
+
+import (
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/flattened"
+	"github.com/andreychh/tgen/model/typeform"
+)
+
+// envelopeRef is the reference of the object naming why a request failed, which
+// a response carries beside the result of whichever method was called. No method
+// names it, so no edge of the graph leads to it: a client decodes it because
+// every response has room for it, and that is knowledge of the transport rather
+// than of any one method.
+const envelopeRef = model.Reference("responseparameters")
+
+// Seeding is where the traversal starts: what a transport touches on its own,
+// without anything having had to reach it. A request carries the parameters of
+// the method it invokes, a response carries what that method hands back, and
+// either way a definition reached this way is reached because of what it is
+// part of, not because of what reached it.
+type Seeding struct {
+	methods flattened.Methods
+	fields  flattened.Fields
+}
+
+// NewSeeding constructs a Seeding over the tables of methods and fields.
+func NewSeeding(methods flattened.Methods, fields flattened.Fields) Seeding {
+	return Seeding{methods: methods, fields: fields}
+}
+
+// Value returns every definition the traversal starts from and how each of them
+// is reached. A reference may be named more than once, one method taking it as
+// a parameter while another hands it back, and it is the merging of the seeds
+// that leaves such a definition travelling both ways.
+func (s Seeding) Value() []Seed {
+	return append(s.outbound(), s.inbound()...)
+}
+
+// outbound returns one seed for every parameter of a method naming a
+// definition, since a request carries whatever the method it invokes was given.
+// A parameter typed as a primitive names no definition and seeds nothing, and a
+// field of an object is no parameter, however alike the two are held.
+func (s Seeding) outbound() []Seed {
+	out := make([]Seed, 0)
+	for key, field := range s.fields.All() {
+		if _, invoked := s.methods.Lookup(key.Owner); !invoked {
+			continue
+		}
+		named, ok := field.Type.Atom().(typeform.Named)
+		if !ok {
+			continue
+		}
+		out = append(out, Seed{Ref: named.Ref(), Reach: ReachOutbound})
+	}
+	return out
+}
+
+// inbound returns one seed for every method return naming a definition, and one
+// for the envelope every response carries besides. A method handing back a
+// primitive — the bare True of a command — names no definition and seeds
+// nothing.
+func (s Seeding) inbound() []Seed {
+	out := []Seed{{Ref: envelopeRef, Reach: ReachInbound}}
+	for _, method := range s.methods.All() {
+		named, ok := method.Type.Atom().(typeform.Named)
+		if !ok {
+			continue
+		}
+		out = append(out, Seed{Ref: named.Ref(), Reach: ReachInbound})
+	}
+	return out
+}

--- a/model/pipeline/directed/specification.go
+++ b/model/pipeline/directed/specification.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+// Package directed decides which way every definition but a method travels:
+// into a request, out of a response, or both. A target reads the direction to
+// leave out an encoder or a decoder nothing could call, a definition no request
+// carries never being written and one no response carries never being read.
+package directed
+
+import (
+	"fmt"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline"
+	"github.com/andreychh/tgen/model/pipeline/attached"
+	"github.com/andreychh/tgen/model/pipeline/classified"
+	"github.com/andreychh/tgen/model/pipeline/corrected"
+	"github.com/andreychh/tgen/model/pipeline/flattened"
+	"github.com/andreychh/tgen/model/pipeline/parsed"
+)
+
+// Directions is the table of which way each definition travels, keyed by
+// reference. A method is absent from it, being an operation rather than
+// something carried: what travels is the parameters it takes and the value it
+// hands back.
+type Directions = pipeline.Table[model.Reference, model.Direction]
+
+// Specification is the database after every definition is told which way it
+// travels. The definition, method, field, file, discriminator, variant, and
+// alias tables and the release ride through from the attached stage unchanged.
+type Specification struct {
+	Definitions    corrected.Definitions
+	Methods        flattened.Methods
+	Fields         flattened.Fields
+	Files          attached.Files
+	Directions     Directions
+	Discriminators classified.Discriminators
+	Variants       parsed.Variants
+	Aliases        flattened.Aliases
+	Release        parsed.Release
+}
+
+// Pass is the directing stage: it rewrites an attached specification into a
+// directed one, spreading the way of travel from what a transport touches on
+// its own to everything the specification reaches from there. It reads the flat
+// types a field, a return, and an alias were reduced to, and nothing a later
+// stage decides, so it stands here.
+type Pass struct {
+	spec attached.Specification
+}
+
+// NewPass constructs a Pass over an attached specification.
+func NewPass(spec attached.Specification) Pass {
+	return Pass{spec: spec}
+}
+
+// Specification returns the directed specification, telling every definition
+// but a method which way it travels. It fails when nothing reaches a
+// definition, which leaves it neither written nor read and so declared for
+// no reason at all.
+func (p Pass) Specification() (Specification, error) {
+	directions, err := p.directions(NewSpread(
+		NewSeeding(p.spec.Methods, p.spec.Fields).Value(),
+		NewFieldRule(p.spec.Fields),
+		NewVariantRule(p.spec.Variants),
+		NewAliasRule(p.spec.Aliases),
+	).Value())
+	if err != nil {
+		return Specification{}, err
+	}
+	return Specification{
+		Definitions:    p.spec.Definitions,
+		Methods:        p.spec.Methods,
+		Fields:         p.spec.Fields,
+		Files:          p.spec.Files,
+		Directions:     directions,
+		Discriminators: p.spec.Discriminators,
+		Variants:       p.spec.Variants,
+		Aliases:        p.spec.Aliases,
+		Release:        p.spec.Release,
+	}, nil
+}
+
+// directions returns the way of travel of every definition the spread settled
+// on, leaving out the methods. It fails when a definition that is no method was
+// reached by nothing.
+func (p Pass) directions(reaches Reaches) (Directions, error) {
+	out := pipeline.NewMapTableWithCapacity[model.Reference, model.Direction](
+		p.spec.Definitions.Count(),
+	)
+	for ref, definition := range p.spec.Definitions.All() {
+		if definition.Kind == model.DefinitionKindMethod {
+			continue
+		}
+		direction, err := reaches.Lookup(ref).Direction()
+		if err != nil {
+			return nil, fmt.Errorf("directing %s: %w", ref, err)
+		}
+		out.Insert(ref, direction)
+	}
+	return out, nil
+}

--- a/model/pipeline/directed/spread.go
+++ b/model/pipeline/directed/spread.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package directed
+
+import "github.com/andreychh/tgen/model"
+
+// Seed is one definition the traversal starts from, and how it is reached. A
+// seed stands for what no [Rule] can say: a parameter goes out because it is
+// part of a request, not because anything reached the method taking it, and a
+// relation producing a reach instead of passing one along is no edge of the
+// graph.
+type Seed struct {
+	Ref   model.Reference
+	Reach Reach
+}
+
+// Spread is the traversal: it starts from the seeds and follows every edge the
+// rules put in the graph until a round raises nothing.
+type Spread struct {
+	seeds []Seed
+	rules []Rule
+}
+
+// NewSpread constructs a Spread starting from seeds and following the edges of
+// the given rules.
+func NewSpread(seeds []Seed, rules ...Rule) Spread {
+	return Spread{seeds: seeds, rules: rules}
+}
+
+// Value returns how far every definition was reached. The rounds repeat until
+// one raises nothing, so a definition holding its own kind — a rich block
+// nesting rich blocks — settles instead of circling.
+func (s Spread) Value() Reaches {
+	out := NewReaches()
+	for _, seed := range s.seeds {
+		out.Merge(seed.Ref, seed.Reach)
+	}
+	for s.round(out) {
+	}
+	return out
+}
+
+// round follows every edge once, carrying what is known of the source into the
+// target, and reports whether that raised anything. An edge leading out of a
+// definition nothing reached carries [ReachNone] and raises nothing, so no edge
+// needs a test of its own.
+func (s Spread) round(out Reaches) bool {
+	grew := false
+	for _, rule := range s.rules {
+		for from, to := range rule.Edges() {
+			raised := out.Merge(to, out.Lookup(from))
+			grew = grew || raised
+		}
+	}
+	return grew
+}

--- a/model/pipeline/separated/specification.go
+++ b/model/pipeline/separated/specification.go
@@ -13,6 +13,7 @@ import (
 	"github.com/andreychh/tgen/model/pipeline/attached"
 	"github.com/andreychh/tgen/model/pipeline/classified"
 	"github.com/andreychh/tgen/model/pipeline/corrected"
+	"github.com/andreychh/tgen/model/pipeline/directed"
 	"github.com/andreychh/tgen/model/pipeline/flattened"
 	"github.com/andreychh/tgen/model/pipeline/parsed"
 )
@@ -21,28 +22,30 @@ import (
 type Methods = pipeline.Table[model.Reference, Method]
 
 // Specification is the database after every method's return is split into what
-// the method signals. The definition, field, discriminator, variant, alias, and
-// file tables and the release ride through from the attached stage unchanged.
+// the method signals. The definition, field, discriminator, variant, alias,
+// file, and direction tables and the release ride through from the directed
+// stage unchanged.
 type Specification struct {
 	Definitions    corrected.Definitions
 	Methods        Methods
 	Fields         flattened.Fields
 	Files          attached.Files
+	Directions     directed.Directions
 	Discriminators classified.Discriminators
 	Variants       parsed.Variants
 	Aliases        flattened.Aliases
 	Release        parsed.Release
 }
 
-// Pass is the separation stage: it rewrites an attached specification into a
+// Pass is the separation stage: it rewrites a directed specification into a
 // separated one, deciding for every method whether its return carries data or
 // only reports success.
 type Pass struct {
-	spec attached.Specification
+	spec directed.Specification
 }
 
-// NewPass constructs a Pass over an attached specification.
-func NewPass(spec attached.Specification) Pass {
+// NewPass constructs a Pass over a directed specification.
+func NewPass(spec directed.Specification) Pass {
 	return Pass{spec: spec}
 }
 
@@ -59,6 +62,7 @@ func (p Pass) Specification() (Specification, error) {
 		Methods:        methods,
 		Fields:         p.spec.Fields,
 		Files:          p.spec.Files,
+		Directions:     p.spec.Directions,
 		Discriminators: p.spec.Discriminators,
 		Variants:       p.spec.Variants,
 		Aliases:        p.spec.Aliases,

--- a/output/mold.go
+++ b/output/mold.go
@@ -5,6 +5,7 @@ package output
 
 import (
 	"embed"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -24,15 +25,26 @@ func NewMold(fs embed.FS, funcs template.FuncMap) Mold {
 
 // Template parses all templates in the embedded filesystem and returns a
 // configured [template.Template]. Beside the configured function map, the
-// returned template exposes two functions letting a caller dispatch on a name
-// computed from the data: render, which executes the template named by its
-// first argument against its second and yields the rendered text, and
-// override, which names the template rendering one definition: the block
-// written by hand for the reference it takes when the templates hold one, and
-// the shape it takes otherwise.
+// returned template exposes three functions: render, which executes the
+// template named by its first argument against its second and yields the
+// rendered text; override, which names the template rendering one definition —
+// the block written by hand for the reference it takes when the templates hold
+// one, and the shape it takes otherwise; and assert, which stops the rendering
+// when what a block was written for stops holding.
 func (m Mold) Template() (*template.Template, error) {
 	tmpl := template.New("").Option("missingkey=error").Funcs(m.funcs)
 	return tmpl.Funcs(template.FuncMap{
+		// assert states what a block written by hand takes for granted, and fails the
+		// rendering with the given message when the specification stops granting it. A
+		// block cannot be generated, so a requirement it does not already answer cannot
+		// be answered by leaving something out — only by a person reading the block
+		// again, which is what a stopped generation is for.
+		"assert": func(holds bool, message string) (string, error) {
+			if !holds {
+				return "", errors.New(message)
+			}
+			return "", nil
+		},
 		"render": func(name string, data any) (string, error) {
 			var b strings.Builder
 			err := tmpl.ExecuteTemplate(&b, name, data)

--- a/stands/gov2/api/api.go
+++ b/stands/gov2/api/api.go
@@ -16927,10 +16927,6 @@ func (InputVenueMessageContent) sealedInputMessageContent() {}
 func (InputContactMessageContent) sealedInputMessageContent() {}
 func (InputInvoiceMessageContent) sealedInputMessageContent() {}
 
-func unmarshalInputMessageContent(data []byte) (InputMessageContent, error) {
-	return nil, fmt.Errorf("InputMessageContent is only ever sent, so %s cannot be read back", data)
-}
-
 // Represents the content of a text message to be sent as the result of an
 // inline query.
 //
@@ -18617,18 +18613,6 @@ type ChatID interface{ sealedChatID() }
 func (ID) sealedChatID() {}
 func (Username) sealedChatID() {}
 
-func unmarshalChatID(data []byte) (ChatID, error) {
-	var id ID
-	if json.Unmarshal(data, &id) == nil {
-		return id, nil
-	}
-	var username Username
-	if json.Unmarshal(data, &username) == nil {
-		return username, nil
-	}
-	return nil, fmt.Errorf("cannot unmarshal %s into ChatID", data)
-}
-
 // ID represents a numeric Telegram chat or user identifier.
 type ID int64
 
@@ -18680,14 +18664,6 @@ type InputFile interface {
 
 func (FileID) sealedInputFile() {}
 func (Upload) sealedInputFile() {}
-
-func unmarshalInputFile(data []byte) (InputFile, error) {
-	var id FileID
-	if err := json.Unmarshal(data, &id); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal %s into InputFile: %w", data, err)
-	}
-	return id, nil
-}
 
 // FileID represents a Telegram file identifier.
 type FileID string

--- a/stands/gov2/api/api.go
+++ b/stands/gov2/api/api.go
@@ -1144,26 +1144,6 @@ type ReplyParameters struct {
 	PollOptionID *string `json:"poll_option_id,omitempty"`
 }
 
-func (o *ReplyParameters) UnmarshalJSON(data []byte) error {
-	type alias ReplyParameters
-	var aux struct {
-		ChatID json.RawMessage `json:"chat_id"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = ReplyParameters(aux.alias)
-	if aux.ChatID != nil {
-		result, err := unmarshalChatID(aux.ChatID)
-		if err != nil {
-			return err
-		}
-		o.ChatID = result
-	}
-	return nil
-}
-
 // This object describes the origin of a message. It can be one of
 //
 // See https://core.telegram.org/bots/api#messageorigin
@@ -1222,17 +1202,6 @@ type MessageOriginUser struct {
 	SenderUser User `json:"sender_user"`
 }
 
-func (o MessageOriginUser) MarshalJSON() ([]byte, error) {
-	type alias MessageOriginUser
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "user",
-		alias: alias(o),
-	})
-}
-
 // The message was originally sent by an unknown user.
 //
 // See https://core.telegram.org/bots/api#messageoriginhiddenuser
@@ -1241,17 +1210,6 @@ type MessageOriginHiddenUser struct {
 	Date int64 `json:"date"`
 	// Name of the user that sent the message originally
 	SenderUserName string `json:"sender_user_name"`
-}
-
-func (o MessageOriginHiddenUser) MarshalJSON() ([]byte, error) {
-	type alias MessageOriginHiddenUser
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "hidden_user",
-		alias: alias(o),
-	})
 }
 
 // The message was originally sent on behalf of a chat to a group chat.
@@ -1267,17 +1225,6 @@ type MessageOriginChat struct {
 	AuthorSignature *string `json:"author_signature,omitempty"`
 }
 
-func (o MessageOriginChat) MarshalJSON() ([]byte, error) {
-	type alias MessageOriginChat
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "chat",
-		alias: alias(o),
-	})
-}
-
 // The message was originally sent to a channel chat.
 //
 // See https://core.telegram.org/bots/api#messageoriginchannel
@@ -1290,17 +1237,6 @@ type MessageOriginChannel struct {
 	MessageID int64 `json:"message_id"`
 	// Signature of the original post author
 	AuthorSignature *string `json:"author_signature,omitempty"`
-}
-
-func (o MessageOriginChannel) MarshalJSON() ([]byte, error) {
-	type alias MessageOriginChannel
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "channel",
-		alias: alias(o),
-	})
 }
 
 // This object represents one size of a photo or a file / sticker thumbnail.
@@ -1625,34 +1561,12 @@ type PaidMediaLivePhoto struct {
 	LivePhoto LivePhoto `json:"live_photo"`
 }
 
-func (o PaidMediaLivePhoto) MarshalJSON() ([]byte, error) {
-	type alias PaidMediaLivePhoto
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "live_photo",
-		alias: alias(o),
-	})
-}
-
 // The paid media is a photo.
 //
 // See https://core.telegram.org/bots/api#paidmediaphoto
 type PaidMediaPhoto struct {
 	// The photo
 	Photo []PhotoSize `json:"photo"`
-}
-
-func (o PaidMediaPhoto) MarshalJSON() ([]byte, error) {
-	type alias PaidMediaPhoto
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "photo",
-		alias: alias(o),
-	})
 }
 
 // The paid media isn't available before the payment.
@@ -1667,34 +1581,12 @@ type PaidMediaPreview struct {
 	Duration *int64 `json:"duration,omitempty"`
 }
 
-func (o PaidMediaPreview) MarshalJSON() ([]byte, error) {
-	type alias PaidMediaPreview
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "preview",
-		alias: alias(o),
-	})
-}
-
 // The paid media is a video.
 //
 // See https://core.telegram.org/bots/api#paidmediavideo
 type PaidMediaVideo struct {
 	// The video
 	Video Video `json:"video"`
-}
-
-func (o PaidMediaVideo) MarshalJSON() ([]byte, error) {
-	type alias PaidMediaVideo
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "video",
-		alias: alias(o),
-	})
 }
 
 // This object represents a phone contact.
@@ -1784,67 +1676,6 @@ func (InputMediaPhoto) sealedInputPollMedia() {}
 func (InputMediaVenue) sealedInputPollMedia() {}
 func (InputMediaVideo) sealedInputPollMedia() {}
 
-func unmarshalInputPollMedia(data []byte) (InputPollMedia, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "animation":
-		var variant InputMediaAnimation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "audio":
-		var variant InputMediaAudio
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "document":
-		var variant InputMediaDocument
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "live_photo":
-		var variant InputMediaLivePhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "location":
-		var variant InputMediaLocation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "photo":
-		var variant InputMediaPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "venue":
-		var variant InputMediaVenue
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputMediaVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputPollMedia %q", mark.Key)
-	}
-}
-
 // This object represents the content of a poll option to be sent. It should be
 // one of
 //
@@ -1863,67 +1694,6 @@ func (InputMediaPhoto) sealedInputPollOptionMedia() {}
 func (InputMediaSticker) sealedInputPollOptionMedia() {}
 func (InputMediaVenue) sealedInputPollOptionMedia() {}
 func (InputMediaVideo) sealedInputPollOptionMedia() {}
-
-func unmarshalInputPollOptionMedia(data []byte) (InputPollOptionMedia, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "animation":
-		var variant InputMediaAnimation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "link":
-		var variant InputMediaLink
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "live_photo":
-		var variant InputMediaLivePhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "location":
-		var variant InputMediaLocation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "photo":
-		var variant InputMediaPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "sticker":
-		var variant InputMediaSticker
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "venue":
-		var variant InputMediaVenue
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputMediaVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputPollOptionMedia %q", mark.Key)
-	}
-}
 
 // This object contains information about one answer option in a poll.
 //
@@ -1966,26 +1736,6 @@ type InputPollOption struct {
 	TextEntities []MessageEntity `json:"text_entities,omitempty"`
 	// Media added to the poll option
 	Media InputPollOptionMedia `json:"media,omitempty"`
-}
-
-func (o *InputPollOption) UnmarshalJSON(data []byte) error {
-	type alias InputPollOption
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputPollOption(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputPollOptionMedia(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	return nil
 }
 
 func (o InputPollOption) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -2401,17 +2151,6 @@ type BackgroundFillSolid struct {
 	Color int64 `json:"color"`
 }
 
-func (o BackgroundFillSolid) MarshalJSON() ([]byte, error) {
-	type alias BackgroundFillSolid
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "solid",
-		alias: alias(o),
-	})
-}
-
 // The background is a gradient fill.
 //
 // See https://core.telegram.org/bots/api#backgroundfillgradient
@@ -2424,17 +2163,6 @@ type BackgroundFillGradient struct {
 	RotationAngle int64 `json:"rotation_angle"`
 }
 
-func (o BackgroundFillGradient) MarshalJSON() ([]byte, error) {
-	type alias BackgroundFillGradient
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "gradient",
-		alias: alias(o),
-	})
-}
-
 // The background is a freeform gradient that rotates after every message in the
 // chat.
 //
@@ -2443,17 +2171,6 @@ type BackgroundFillFreeformGradient struct {
 	// A list of the 3 or 4 base colors that are used to generate the freeform
 	// gradient in the RGB24 format
 	Colors []int64 `json:"colors"`
-}
-
-func (o BackgroundFillFreeformGradient) MarshalJSON() ([]byte, error) {
-	type alias BackgroundFillFreeformGradient
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "freeform_gradient",
-		alias: alias(o),
-	})
 }
 
 // This object describes the type of a background. Currently, it can be one of
@@ -2514,17 +2231,6 @@ type BackgroundTypeFill struct {
 	DarkThemeDimming int64 `json:"dark_theme_dimming"`
 }
 
-func (o BackgroundTypeFill) MarshalJSON() ([]byte, error) {
-	type alias BackgroundTypeFill
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "fill",
-		alias: alias(o),
-	})
-}
-
 func (o *BackgroundTypeFill) UnmarshalJSON(data []byte) error {
 	type alias BackgroundTypeFill
 	var aux struct {
@@ -2560,17 +2266,6 @@ type BackgroundTypeWallpaper struct {
 	IsMoving *bool `json:"is_moving,omitempty"`
 }
 
-func (o BackgroundTypeWallpaper) MarshalJSON() ([]byte, error) {
-	type alias BackgroundTypeWallpaper
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "wallpaper",
-		alias: alias(o),
-	})
-}
-
 // The background is a .PNG or .TGV (gzipped subset of SVG with MIME type
 // “application/x-tgwallpattern”) pattern to be combined with the background
 // fill chosen by the user.
@@ -2588,17 +2283,6 @@ type BackgroundTypePattern struct {
 	IsInverted *bool `json:"is_inverted,omitempty"`
 	// True, if the background moves slightly when the device is tilted
 	IsMoving *bool `json:"is_moving,omitempty"`
-}
-
-func (o BackgroundTypePattern) MarshalJSON() ([]byte, error) {
-	type alias BackgroundTypePattern
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "pattern",
-		alias: alias(o),
-	})
 }
 
 func (o *BackgroundTypePattern) UnmarshalJSON(data []byte) error {
@@ -2627,17 +2311,6 @@ func (o *BackgroundTypePattern) UnmarshalJSON(data []byte) error {
 type BackgroundTypeChatTheme struct {
 	// Name of the chat theme, which is usually an emoji
 	ThemeName string `json:"theme_name"`
-}
-
-func (o BackgroundTypeChatTheme) MarshalJSON() ([]byte, error) {
-	type alias BackgroundTypeChatTheme
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "chat_theme",
-		alias: alias(o),
-	})
 }
 
 // This object represents a chat background.
@@ -3868,17 +3541,6 @@ type ChatMemberOwner struct {
 	CustomTitle *string `json:"custom_title,omitempty"`
 }
 
-func (o ChatMemberOwner) MarshalJSON() ([]byte, error) {
-	type alias ChatMemberOwner
-	return json.Marshal(struct {
-		Status string `json:"status"`
-		alias
-	}{
-		Status: "creator",
-		alias: alias(o),
-	})
-}
-
 // Represents a chat member that has some additional privileges.
 //
 // See https://core.telegram.org/bots/api#chatmemberadministrator
@@ -3939,17 +3601,6 @@ type ChatMemberAdministrator struct {
 	CustomTitle *string `json:"custom_title,omitempty"`
 }
 
-func (o ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
-	type alias ChatMemberAdministrator
-	return json.Marshal(struct {
-		Status string `json:"status"`
-		alias
-	}{
-		Status: "administrator",
-		alias: alias(o),
-	})
-}
-
 // Represents a chat member that has no additional privileges or restrictions.
 //
 // See https://core.telegram.org/bots/api#chatmembermember
@@ -3960,17 +3611,6 @@ type ChatMemberMember struct {
 	Tag *string `json:"tag,omitempty"`
 	// Date when the user's subscription will expire; Unix time
 	UntilDate *int64 `json:"until_date,omitempty"`
-}
-
-func (o ChatMemberMember) MarshalJSON() ([]byte, error) {
-	type alias ChatMemberMember
-	return json.Marshal(struct {
-		Status string `json:"status"`
-		alias
-	}{
-		Status: "member",
-		alias: alias(o),
-	})
 }
 
 // Represents a chat member that is under certain restrictions in the chat.
@@ -4024,17 +3664,6 @@ type ChatMemberRestricted struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
-func (o ChatMemberRestricted) MarshalJSON() ([]byte, error) {
-	type alias ChatMemberRestricted
-	return json.Marshal(struct {
-		Status string `json:"status"`
-		alias
-	}{
-		Status: "restricted",
-		alias: alias(o),
-	})
-}
-
 // Represents a chat member that isn't currently a member of the chat, but may
 // join it themselves.
 //
@@ -4042,17 +3671,6 @@ func (o ChatMemberRestricted) MarshalJSON() ([]byte, error) {
 type ChatMemberLeft struct {
 	// Information about the user
 	User User `json:"user"`
-}
-
-func (o ChatMemberLeft) MarshalJSON() ([]byte, error) {
-	type alias ChatMemberLeft
-	return json.Marshal(struct {
-		Status string `json:"status"`
-		alias
-	}{
-		Status: "left",
-		alias: alias(o),
-	})
 }
 
 // Represents a chat member that was banned in the chat and can't return to the
@@ -4065,17 +3683,6 @@ type ChatMemberBanned struct {
 	// Date when restrictions will be lifted for this user; Unix time. If 0, then
 	// the user is banned forever.
 	UntilDate int64 `json:"until_date"`
-}
-
-func (o ChatMemberBanned) MarshalJSON() ([]byte, error) {
-	type alias ChatMemberBanned
-	return json.Marshal(struct {
-		Status string `json:"status"`
-		alias
-	}{
-		Status: "kicked",
-		alias: alias(o),
-	})
 }
 
 // Represents a join request sent to a chat.
@@ -4272,49 +3879,6 @@ func (StoryAreaTypeLink) sealedStoryAreaType() {}
 func (StoryAreaTypeWeather) sealedStoryAreaType() {}
 func (StoryAreaTypeUniqueGift) sealedStoryAreaType() {}
 
-func unmarshalStoryAreaType(data []byte) (StoryAreaType, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "location":
-		var variant StoryAreaTypeLocation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "suggested_reaction":
-		var variant StoryAreaTypeSuggestedReaction
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "link":
-		var variant StoryAreaTypeLink
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "weather":
-		var variant StoryAreaTypeWeather
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "unique_gift":
-		var variant StoryAreaTypeUniqueGift
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown StoryAreaType %q", mark.Key)
-	}
-}
-
 // Describes a story area pointing to a location. Currently, a story can have up
 // to 10 location areas.
 //
@@ -4361,26 +3925,6 @@ func (o StoryAreaTypeSuggestedReaction) MarshalJSON() ([]byte, error) {
 		Type: "suggested_reaction",
 		alias: alias(o),
 	})
-}
-
-func (o *StoryAreaTypeSuggestedReaction) UnmarshalJSON(data []byte) error {
-	type alias StoryAreaTypeSuggestedReaction
-	var aux struct {
-		ReactionType json.RawMessage `json:"reaction_type"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = StoryAreaTypeSuggestedReaction(aux.alias)
-	if aux.ReactionType != nil {
-		result, err := unmarshalReactionType(aux.ReactionType)
-		if err != nil {
-			return err
-		}
-		o.ReactionType = result
-	}
-	return nil
 }
 
 // Describes a story area pointing to an HTTP or tg:// link. Currently, a story
@@ -4455,26 +3999,6 @@ type StoryArea struct {
 	Position StoryAreaPosition `json:"position"`
 	// Type of the area
 	Type StoryAreaType `json:"type"`
-}
-
-func (o *StoryArea) UnmarshalJSON(data []byte) error {
-	type alias StoryArea
-	var aux struct {
-		Type json.RawMessage `json:"type"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = StoryArea(aux.alias)
-	if aux.Type != nil {
-		result, err := unmarshalStoryAreaType(aux.Type)
-		if err != nil {
-			return err
-		}
-		o.Type = result
-	}
-	return nil
 }
 
 // Represents a location to which a chat is connected.
@@ -5018,17 +4542,6 @@ type OwnedGiftRegular struct {
 	UniqueGiftNumber *int64 `json:"unique_gift_number,omitempty"`
 }
 
-func (o OwnedGiftRegular) MarshalJSON() ([]byte, error) {
-	type alias OwnedGiftRegular
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "regular",
-		alias: alias(o),
-	})
-}
-
 // Describes a unique gift received and owned by a user or a chat.
 //
 // See https://core.telegram.org/bots/api#ownedgiftunique
@@ -5054,17 +4567,6 @@ type OwnedGiftUnique struct {
 	// Point in time (Unix timestamp) when the gift can be transferred. If it is in
 	// the past, then the gift can be transferred now.
 	NextTransferDate *int64 `json:"next_transfer_date,omitempty"`
-}
-
-func (o OwnedGiftUnique) MarshalJSON() ([]byte, error) {
-	type alias OwnedGiftUnique
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "unique",
-		alias: alias(o),
-	})
 }
 
 // Contains the list of gifts received and owned by a user or a chat.
@@ -5173,61 +4675,6 @@ func (BotCommandScopeChat) sealedBotCommandScope() {}
 func (BotCommandScopeChatAdministrators) sealedBotCommandScope() {}
 func (BotCommandScopeChatMember) sealedBotCommandScope() {}
 
-func unmarshalBotCommandScope(data []byte) (BotCommandScope, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "default":
-		var variant BotCommandScopeDefault
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "all_private_chats":
-		var variant BotCommandScopeAllPrivateChats
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "all_group_chats":
-		var variant BotCommandScopeAllGroupChats
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "all_chat_administrators":
-		var variant BotCommandScopeAllChatAdministrators
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "chat":
-		var variant BotCommandScopeChat
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "chat_administrators":
-		var variant BotCommandScopeChatAdministrators
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "chat_member":
-		var variant BotCommandScopeChatMember
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown BotCommandScope %q", mark.Key)
-	}
-}
-
 // Represents the default scope of bot commands. Default commands are used if no
 // commands with a narrower scope are specified for the user.
 //
@@ -5320,26 +4767,6 @@ func (o BotCommandScopeChat) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *BotCommandScopeChat) UnmarshalJSON(data []byte) error {
-	type alias BotCommandScopeChat
-	var aux struct {
-		ChatID json.RawMessage `json:"chat_id"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = BotCommandScopeChat(aux.alias)
-	if aux.ChatID != nil {
-		result, err := unmarshalChatID(aux.ChatID)
-		if err != nil {
-			return err
-		}
-		o.ChatID = result
-	}
-	return nil
-}
-
 // Represents the scope of bot commands, covering all administrators of a
 // specific group or supergroup chat.
 //
@@ -5360,26 +4787,6 @@ func (o BotCommandScopeChatAdministrators) MarshalJSON() ([]byte, error) {
 		Type: "chat_administrators",
 		alias: alias(o),
 	})
-}
-
-func (o *BotCommandScopeChatAdministrators) UnmarshalJSON(data []byte) error {
-	type alias BotCommandScopeChatAdministrators
-	var aux struct {
-		ChatID json.RawMessage `json:"chat_id"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = BotCommandScopeChatAdministrators(aux.alias)
-	if aux.ChatID != nil {
-		result, err := unmarshalChatID(aux.ChatID)
-		if err != nil {
-			return err
-		}
-		o.ChatID = result
-	}
-	return nil
 }
 
 // Represents the scope of bot commands, covering a specific member of a group
@@ -5404,26 +4811,6 @@ func (o BotCommandScopeChatMember) MarshalJSON() ([]byte, error) {
 		Type: "chat_member",
 		alias: alias(o),
 	})
-}
-
-func (o *BotCommandScopeChatMember) UnmarshalJSON(data []byte) error {
-	type alias BotCommandScopeChatMember
-	var aux struct {
-		ChatID json.RawMessage `json:"chat_id"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = BotCommandScopeChatMember(aux.alias)
-	if aux.ChatID != nil {
-		result, err := unmarshalChatID(aux.ChatID)
-		if err != nil {
-			return err
-		}
-		o.ChatID = result
-	}
-	return nil
 }
 
 // This object represents the bot's name.
@@ -5606,17 +4993,6 @@ type ChatBoostSourcePremium struct {
 	User User `json:"user"`
 }
 
-func (o ChatBoostSourcePremium) MarshalJSON() ([]byte, error) {
-	type alias ChatBoostSourcePremium
-	return json.Marshal(struct {
-		Source string `json:"source"`
-		alias
-	}{
-		Source: "premium",
-		alias: alias(o),
-	})
-}
-
 // The boost was obtained by the creation of Telegram Premium gift codes to
 // boost a chat. Each such code boosts the chat 4 times for the duration of the
 // corresponding Telegram Premium subscription.
@@ -5625,17 +5001,6 @@ func (o ChatBoostSourcePremium) MarshalJSON() ([]byte, error) {
 type ChatBoostSourceGiftCode struct {
 	// User for which the gift code was created
 	User User `json:"user"`
-}
-
-func (o ChatBoostSourceGiftCode) MarshalJSON() ([]byte, error) {
-	type alias ChatBoostSourceGiftCode
-	return json.Marshal(struct {
-		Source string `json:"source"`
-		alias
-	}{
-		Source: "gift_code",
-		alias: alias(o),
-	})
 }
 
 // The boost was obtained by the creation of a Telegram Premium or a Telegram
@@ -5656,17 +5021,6 @@ type ChatBoostSourceGiveaway struct {
 	PrizeStarCount *int64 `json:"prize_star_count,omitempty"`
 	// True, if the giveaway was completed, but there was no user to win the prize
 	IsUnclaimed *bool `json:"is_unclaimed,omitempty"`
-}
-
-func (o ChatBoostSourceGiveaway) MarshalJSON() ([]byte, error) {
-	type alias ChatBoostSourceGiveaway
-	return json.Marshal(struct {
-		Source string `json:"source"`
-		alias
-	}{
-		Source: "giveaway",
-		alias: alias(o),
-	})
 }
 
 // This object contains information about a chat boost.
@@ -5918,55 +5272,6 @@ func (InputMediaLivePhoto) sealedInputMedia() {}
 func (InputMediaPhoto) sealedInputMedia() {}
 func (InputMediaVideo) sealedInputMedia() {}
 
-func unmarshalInputMedia(data []byte) (InputMedia, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "animation":
-		var variant InputMediaAnimation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "audio":
-		var variant InputMediaAudio
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "document":
-		var variant InputMediaDocument
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "live_photo":
-		var variant InputMediaLivePhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "photo":
-		var variant InputMediaPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputMediaVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputMedia %q", mark.Key)
-	}
-}
-
 // Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to
 // be sent.
 //
@@ -6016,34 +5321,6 @@ func (o InputMediaAnimation) MarshalJSON() ([]byte, error) {
 		Type: "animation",
 		alias: alias(o),
 	})
-}
-
-func (o *InputMediaAnimation) UnmarshalJSON(data []byte) error {
-	type alias InputMediaAnimation
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		Thumbnail json.RawMessage `json:"thumbnail"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaAnimation(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	if aux.Thumbnail != nil {
-		result, err := unmarshalInputFile(aux.Thumbnail)
-		if err != nil {
-			return err
-		}
-		o.Thumbnail = result
-	}
-	return nil
 }
 
 func (o InputMediaAnimation) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -6113,34 +5390,6 @@ func (o InputMediaAudio) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputMediaAudio) UnmarshalJSON(data []byte) error {
-	type alias InputMediaAudio
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		Thumbnail json.RawMessage `json:"thumbnail"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaAudio(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	if aux.Thumbnail != nil {
-		result, err := unmarshalInputFile(aux.Thumbnail)
-		if err != nil {
-			return err
-		}
-		o.Thumbnail = result
-	}
-	return nil
-}
-
 func (o InputMediaAudio) resolve(sink *fileSink) (json.RawMessage, error) {
 	media := o.Media.attach(sink)
 	var thumbnail *string
@@ -6204,34 +5453,6 @@ func (o InputMediaDocument) MarshalJSON() ([]byte, error) {
 		Type: "document",
 		alias: alias(o),
 	})
-}
-
-func (o *InputMediaDocument) UnmarshalJSON(data []byte) error {
-	type alias InputMediaDocument
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		Thumbnail json.RawMessage `json:"thumbnail"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaDocument(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	if aux.Thumbnail != nil {
-		result, err := unmarshalInputFile(aux.Thumbnail)
-		if err != nil {
-			return err
-		}
-		o.Thumbnail = result
-	}
-	return nil
 }
 
 func (o InputMediaDocument) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -6320,34 +5541,6 @@ func (o InputMediaLivePhoto) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputMediaLivePhoto) UnmarshalJSON(data []byte) error {
-	type alias InputMediaLivePhoto
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		Photo json.RawMessage `json:"photo"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaLivePhoto(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	if aux.Photo != nil {
-		result, err := unmarshalInputFile(aux.Photo)
-		if err != nil {
-			return err
-		}
-		o.Photo = result
-	}
-	return nil
-}
-
 func (o InputMediaLivePhoto) resolve(sink *fileSink) (json.RawMessage, error) {
 	media := o.Media.attach(sink)
 	photo := o.Photo.attach(sink)
@@ -6427,26 +5620,6 @@ func (o InputMediaPhoto) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputMediaPhoto) UnmarshalJSON(data []byte) error {
-	type alias InputMediaPhoto
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaPhoto(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	return nil
-}
-
 func (o InputMediaPhoto) resolve(sink *fileSink) (json.RawMessage, error) {
 	media := o.Media.attach(sink)
 	type alias InputMediaPhoto
@@ -6484,26 +5657,6 @@ func (o InputMediaSticker) MarshalJSON() ([]byte, error) {
 		Type: "sticker",
 		alias: alias(o),
 	})
-}
-
-func (o *InputMediaSticker) UnmarshalJSON(data []byte) error {
-	type alias InputMediaSticker
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaSticker(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	return nil
 }
 
 func (o InputMediaSticker) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -6619,42 +5772,6 @@ func (o InputMediaVideo) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputMediaVideo) UnmarshalJSON(data []byte) error {
-	type alias InputMediaVideo
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		Thumbnail json.RawMessage `json:"thumbnail"`
-		Cover json.RawMessage `json:"cover"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaVideo(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	if aux.Thumbnail != nil {
-		result, err := unmarshalInputFile(aux.Thumbnail)
-		if err != nil {
-			return err
-		}
-		o.Thumbnail = result
-	}
-	if aux.Cover != nil {
-		result, err := unmarshalInputFile(aux.Cover)
-		if err != nil {
-			return err
-		}
-		o.Cover = result
-	}
-	return nil
-}
-
 func (o InputMediaVideo) resolve(sink *fileSink) (json.RawMessage, error) {
 	media := o.Media.attach(sink)
 	var thumbnail *string
@@ -6717,26 +5834,6 @@ func (o InputMediaVoiceNote) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputMediaVoiceNote) UnmarshalJSON(data []byte) error {
-	type alias InputMediaVoiceNote
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputMediaVoiceNote(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	return nil
-}
-
 func (o InputMediaVoiceNote) resolve(sink *fileSink) (json.RawMessage, error) {
 	media := o.Media.attach(sink)
 	type alias InputMediaVoiceNote
@@ -6763,37 +5860,6 @@ type InputPaidMedia interface {
 func (InputPaidMediaLivePhoto) sealedInputPaidMedia() {}
 func (InputPaidMediaPhoto) sealedInputPaidMedia() {}
 func (InputPaidMediaVideo) sealedInputPaidMedia() {}
-
-func unmarshalInputPaidMedia(data []byte) (InputPaidMedia, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "live_photo":
-		var variant InputPaidMediaLivePhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "photo":
-		var variant InputPaidMediaPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputPaidMediaVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputPaidMedia %q", mark.Key)
-	}
-}
 
 // The paid media to send is a live photo.
 //
@@ -6822,34 +5888,6 @@ func (o InputPaidMediaLivePhoto) MarshalJSON() ([]byte, error) {
 		Type: "live_photo",
 		alias: alias(o),
 	})
-}
-
-func (o *InputPaidMediaLivePhoto) UnmarshalJSON(data []byte) error {
-	type alias InputPaidMediaLivePhoto
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		Photo json.RawMessage `json:"photo"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputPaidMediaLivePhoto(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	if aux.Photo != nil {
-		result, err := unmarshalInputFile(aux.Photo)
-		if err != nil {
-			return err
-		}
-		o.Photo = result
-	}
-	return nil
 }
 
 func (o InputPaidMediaLivePhoto) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -6890,26 +5928,6 @@ func (o InputPaidMediaPhoto) MarshalJSON() ([]byte, error) {
 		Type: "photo",
 		alias: alias(o),
 	})
-}
-
-func (o *InputPaidMediaPhoto) UnmarshalJSON(data []byte) error {
-	type alias InputPaidMediaPhoto
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputPaidMediaPhoto(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	return nil
 }
 
 func (o InputPaidMediaPhoto) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -6974,42 +5992,6 @@ func (o InputPaidMediaVideo) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputPaidMediaVideo) UnmarshalJSON(data []byte) error {
-	type alias InputPaidMediaVideo
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		Thumbnail json.RawMessage `json:"thumbnail"`
-		Cover json.RawMessage `json:"cover"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputPaidMediaVideo(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputFile(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	if aux.Thumbnail != nil {
-		result, err := unmarshalInputFile(aux.Thumbnail)
-		if err != nil {
-			return err
-		}
-		o.Thumbnail = result
-	}
-	if aux.Cover != nil {
-		result, err := unmarshalInputFile(aux.Cover)
-		if err != nil {
-			return err
-		}
-		o.Cover = result
-	}
-	return nil
-}
-
 func (o InputPaidMediaVideo) resolve(sink *fileSink) (json.RawMessage, error) {
 	media := o.Media.attach(sink)
 	var thumbnail *string
@@ -7050,31 +6032,6 @@ type InputProfilePhoto interface {
 func (InputProfilePhotoStatic) sealedInputProfilePhoto() {}
 func (InputProfilePhotoAnimated) sealedInputProfilePhoto() {}
 
-func unmarshalInputProfilePhoto(data []byte) (InputProfilePhoto, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "static":
-		var variant InputProfilePhotoStatic
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "animated":
-		var variant InputProfilePhotoAnimated
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputProfilePhoto %q", mark.Key)
-	}
-}
-
 // A static profile photo in the .JPG format.
 //
 // See https://core.telegram.org/bots/api#inputprofilephotostatic
@@ -7095,26 +6052,6 @@ func (o InputProfilePhotoStatic) MarshalJSON() ([]byte, error) {
 		Type: "static",
 		alias: alias(o),
 	})
-}
-
-func (o *InputProfilePhotoStatic) UnmarshalJSON(data []byte) error {
-	type alias InputProfilePhotoStatic
-	var aux struct {
-		Photo json.RawMessage `json:"photo"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputProfilePhotoStatic(aux.alias)
-	if aux.Photo != nil {
-		result, err := unmarshalInputFile(aux.Photo)
-		if err != nil {
-			return err
-		}
-		o.Photo = result
-	}
-	return nil
 }
 
 func (o InputProfilePhotoStatic) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -7156,26 +6093,6 @@ func (o InputProfilePhotoAnimated) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputProfilePhotoAnimated) UnmarshalJSON(data []byte) error {
-	type alias InputProfilePhotoAnimated
-	var aux struct {
-		Animation json.RawMessage `json:"animation"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputProfilePhotoAnimated(aux.alias)
-	if aux.Animation != nil {
-		result, err := unmarshalInputFile(aux.Animation)
-		if err != nil {
-			return err
-		}
-		o.Animation = result
-	}
-	return nil
-}
-
 func (o InputProfilePhotoAnimated) resolve(sink *fileSink) (json.RawMessage, error) {
 	animation := o.Animation.attach(sink)
 	type alias InputProfilePhotoAnimated
@@ -7203,31 +6120,6 @@ type InputStoryContent interface {
 func (InputStoryContentPhoto) sealedInputStoryContent() {}
 func (InputStoryContentVideo) sealedInputStoryContent() {}
 
-func unmarshalInputStoryContent(data []byte) (InputStoryContent, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "photo":
-		var variant InputStoryContentPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputStoryContentVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputStoryContent %q", mark.Key)
-	}
-}
-
 // Describes a photo to post as a story.
 //
 // See https://core.telegram.org/bots/api#inputstorycontentphoto
@@ -7249,26 +6141,6 @@ func (o InputStoryContentPhoto) MarshalJSON() ([]byte, error) {
 		Type: "photo",
 		alias: alias(o),
 	})
-}
-
-func (o *InputStoryContentPhoto) UnmarshalJSON(data []byte) error {
-	type alias InputStoryContentPhoto
-	var aux struct {
-		Photo json.RawMessage `json:"photo"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputStoryContentPhoto(aux.alias)
-	if aux.Photo != nil {
-		result, err := unmarshalInputFile(aux.Photo)
-		if err != nil {
-			return err
-		}
-		o.Photo = result
-	}
-	return nil
 }
 
 func (o InputStoryContentPhoto) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -7315,26 +6187,6 @@ func (o InputStoryContentVideo) MarshalJSON() ([]byte, error) {
 		Type: "video",
 		alias: alias(o),
 	})
-}
-
-func (o *InputStoryContentVideo) UnmarshalJSON(data []byte) error {
-	type alias InputStoryContentVideo
-	var aux struct {
-		Video json.RawMessage `json:"video"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputStoryContentVideo(aux.alias)
-	if aux.Video != nil {
-		result, err := unmarshalInputFile(aux.Video)
-		if err != nil {
-			return err
-		}
-		o.Video = result
-	}
-	return nil
 }
 
 func (o InputStoryContentVideo) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -13340,26 +12192,6 @@ type InputSticker struct {
 	Keywords []string `json:"keywords,omitempty"`
 }
 
-func (o *InputSticker) UnmarshalJSON(data []byte) error {
-	type alias InputSticker
-	var aux struct {
-		Sticker json.RawMessage `json:"sticker"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputSticker(aux.alias)
-	if aux.Sticker != nil {
-		result, err := unmarshalInputFile(aux.Sticker)
-		if err != nil {
-			return err
-		}
-		o.Sticker = result
-	}
-	return nil
-}
-
 func (o InputSticker) resolve(sink *fileSink) (json.RawMessage, error) {
 	sticker := o.Sticker.attach(sink)
 	type alias InputSticker
@@ -13986,30 +12818,6 @@ type InputRichMessage struct {
 	SkipEntityDetection *bool `json:"skip_entity_detection,omitempty"`
 }
 
-func (o *InputRichMessage) UnmarshalJSON(data []byte) error {
-	type alias InputRichMessage
-	var aux struct {
-		Blocks []json.RawMessage `json:"blocks"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichMessage(aux.alias)
-	if aux.Blocks != nil {
-		result := make([]InputRichBlock, len(aux.Blocks))
-		for i, raw := range aux.Blocks {
-			v, err := unmarshalInputRichBlock(raw)
-			if err != nil {
-				return err
-			}
-			result[i] = v
-		}
-		o.Blocks = result
-	}
-	return nil
-}
-
 func (o InputRichMessage) resolve(sink *fileSink) (json.RawMessage, error) {
 	blocks := make([]json.RawMessage, len(o.Blocks))
 	for i, el := range o.Blocks {
@@ -14050,26 +12858,6 @@ type InputRichMessageMedia struct {
 	// The media to be sent. Everything except the media itself and its properties
 	// is ignored.
 	Media InputRichMedia `json:"media"`
-}
-
-func (o *InputRichMessageMedia) UnmarshalJSON(data []byte) error {
-	type alias InputRichMessageMedia
-	var aux struct {
-		Media json.RawMessage `json:"media"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichMessageMedia(aux.alias)
-	if aux.Media != nil {
-		result, err := unmarshalInputRichMedia(aux.Media)
-		if err != nil {
-			return err
-		}
-		o.Media = result
-	}
-	return nil
 }
 
 func (o InputRichMessageMedia) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -15516,17 +14304,6 @@ type RichBlockParagraph struct {
 	Text RichText `json:"text"`
 }
 
-func (o RichBlockParagraph) MarshalJSON() ([]byte, error) {
-	type alias RichBlockParagraph
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "paragraph",
-		alias: alias(o),
-	})
-}
-
 func (o *RichBlockParagraph) UnmarshalJSON(data []byte) error {
 	type alias RichBlockParagraph
 	var aux struct {
@@ -15556,17 +14333,6 @@ type RichBlockSectionHeading struct {
 	Text RichText `json:"text"`
 	// Relative size of the text font; 1-6, 1 is the largest, 6 is the smallest
 	Size int64 `json:"size"`
-}
-
-func (o RichBlockSectionHeading) MarshalJSON() ([]byte, error) {
-	type alias RichBlockSectionHeading
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "heading",
-		alias: alias(o),
-	})
 }
 
 func (o *RichBlockSectionHeading) UnmarshalJSON(data []byte) error {
@@ -15600,17 +14366,6 @@ type RichBlockPreformatted struct {
 	Language *string `json:"language,omitempty"`
 }
 
-func (o RichBlockPreformatted) MarshalJSON() ([]byte, error) {
-	type alias RichBlockPreformatted
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "pre",
-		alias: alias(o),
-	})
-}
-
 func (o *RichBlockPreformatted) UnmarshalJSON(data []byte) error {
 	type alias RichBlockPreformatted
 	var aux struct {
@@ -15639,17 +14394,6 @@ type RichBlockFooter struct {
 	Text RichText `json:"text"`
 }
 
-func (o RichBlockFooter) MarshalJSON() ([]byte, error) {
-	type alias RichBlockFooter
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "footer",
-		alias: alias(o),
-	})
-}
-
 func (o *RichBlockFooter) UnmarshalJSON(data []byte) error {
 	type alias RichBlockFooter
 	var aux struct {
@@ -15676,17 +14420,6 @@ func (o *RichBlockFooter) UnmarshalJSON(data []byte) error {
 type RichBlockDivider struct {
 }
 
-func (o RichBlockDivider) MarshalJSON() ([]byte, error) {
-	type alias RichBlockDivider
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "divider",
-		alias: alias(o),
-	})
-}
-
 // A block with a mathematical expression in LaTeX format, corresponding to the
 // custom HTML tag <tg-math-block>.
 //
@@ -15694,17 +14427,6 @@ func (o RichBlockDivider) MarshalJSON() ([]byte, error) {
 type RichBlockMathematicalExpression struct {
 	// The mathematical expression in LaTeX format
 	Expression string `json:"expression"`
-}
-
-func (o RichBlockMathematicalExpression) MarshalJSON() ([]byte, error) {
-	type alias RichBlockMathematicalExpression
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "mathematical_expression",
-		alias: alias(o),
-	})
 }
 
 // A block with an anchor, corresponding to the HTML tag <a> with the attribute
@@ -15716,17 +14438,6 @@ type RichBlockAnchor struct {
 	Name string `json:"name"`
 }
 
-func (o RichBlockAnchor) MarshalJSON() ([]byte, error) {
-	type alias RichBlockAnchor
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "anchor",
-		alias: alias(o),
-	})
-}
-
 // A list of blocks, corresponding to the HTML tag <ul> or <ol> with multiple
 // nested tags <li>.
 //
@@ -15734,17 +14445,6 @@ func (o RichBlockAnchor) MarshalJSON() ([]byte, error) {
 type RichBlockList struct {
 	// Items of the list
 	Items []RichBlockListItem `json:"items"`
-}
-
-func (o RichBlockList) MarshalJSON() ([]byte, error) {
-	type alias RichBlockList
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "list",
-		alias: alias(o),
-	})
 }
 
 // A block quotation, corresponding to the HTML tag <blockquote>.
@@ -15755,17 +14455,6 @@ type RichBlockBlockQuotation struct {
 	Blocks []RichBlock `json:"blocks"`
 	// Credit of the block
 	Credit RichText `json:"credit,omitempty"`
-}
-
-func (o RichBlockBlockQuotation) MarshalJSON() ([]byte, error) {
-	type alias RichBlockBlockQuotation
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "blockquote",
-		alias: alias(o),
-	})
 }
 
 func (o *RichBlockBlockQuotation) UnmarshalJSON(data []byte) error {
@@ -15811,17 +14500,6 @@ type RichBlockPullQuotation struct {
 	Credit RichText `json:"credit,omitempty"`
 }
 
-func (o RichBlockPullQuotation) MarshalJSON() ([]byte, error) {
-	type alias RichBlockPullQuotation
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "pullquote",
-		alias: alias(o),
-	})
-}
-
 func (o *RichBlockPullQuotation) UnmarshalJSON(data []byte) error {
 	type alias RichBlockPullQuotation
 	var aux struct {
@@ -15860,17 +14538,6 @@ type RichBlockCollage struct {
 	Caption *RichBlockCaption `json:"caption,omitempty"`
 }
 
-func (o RichBlockCollage) MarshalJSON() ([]byte, error) {
-	type alias RichBlockCollage
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "collage",
-		alias: alias(o),
-	})
-}
-
 func (o *RichBlockCollage) UnmarshalJSON(data []byte) error {
 	type alias RichBlockCollage
 	var aux struct {
@@ -15903,17 +14570,6 @@ type RichBlockSlideshow struct {
 	Blocks []RichBlock `json:"blocks"`
 	// Caption of the block
 	Caption *RichBlockCaption `json:"caption,omitempty"`
-}
-
-func (o RichBlockSlideshow) MarshalJSON() ([]byte, error) {
-	type alias RichBlockSlideshow
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "slideshow",
-		alias: alias(o),
-	})
 }
 
 func (o *RichBlockSlideshow) UnmarshalJSON(data []byte) error {
@@ -15954,17 +14610,6 @@ type RichBlockTable struct {
 	Caption RichText `json:"caption,omitempty"`
 }
 
-func (o RichBlockTable) MarshalJSON() ([]byte, error) {
-	type alias RichBlockTable
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "table",
-		alias: alias(o),
-	})
-}
-
 func (o *RichBlockTable) UnmarshalJSON(data []byte) error {
 	type alias RichBlockTable
 	var aux struct {
@@ -15996,17 +14641,6 @@ type RichBlockDetails struct {
 	Blocks []RichBlock `json:"blocks"`
 	// True, if the content of the block is visible by default
 	IsOpen *bool `json:"is_open,omitempty"`
-}
-
-func (o RichBlockDetails) MarshalJSON() ([]byte, error) {
-	type alias RichBlockDetails
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "details",
-		alias: alias(o),
-	})
 }
 
 func (o *RichBlockDetails) UnmarshalJSON(data []byte) error {
@@ -16057,17 +14691,6 @@ type RichBlockMap struct {
 	Caption *RichBlockCaption `json:"caption,omitempty"`
 }
 
-func (o RichBlockMap) MarshalJSON() ([]byte, error) {
-	type alias RichBlockMap
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "map",
-		alias: alias(o),
-	})
-}
-
 // A block with an animation, corresponding to the HTML tag <video>.
 //
 // See https://core.telegram.org/bots/api#richblockanimation
@@ -16080,17 +14703,6 @@ type RichBlockAnimation struct {
 	Caption *RichBlockCaption `json:"caption,omitempty"`
 }
 
-func (o RichBlockAnimation) MarshalJSON() ([]byte, error) {
-	type alias RichBlockAnimation
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "animation",
-		alias: alias(o),
-	})
-}
-
 // A block with a music file, corresponding to the HTML tag <audio>.
 //
 // See https://core.telegram.org/bots/api#richblockaudio
@@ -16099,17 +14711,6 @@ type RichBlockAudio struct {
 	Audio Audio `json:"audio"`
 	// Caption of the block
 	Caption *RichBlockCaption `json:"caption,omitempty"`
-}
-
-func (o RichBlockAudio) MarshalJSON() ([]byte, error) {
-	type alias RichBlockAudio
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "audio",
-		alias: alias(o),
-	})
 }
 
 // A block with a photo, corresponding to the HTML tag <img>.
@@ -16124,17 +14725,6 @@ type RichBlockPhoto struct {
 	Caption *RichBlockCaption `json:"caption,omitempty"`
 }
 
-func (o RichBlockPhoto) MarshalJSON() ([]byte, error) {
-	type alias RichBlockPhoto
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "photo",
-		alias: alias(o),
-	})
-}
-
 // A block with a video, corresponding to the HTML tag <video>.
 //
 // See https://core.telegram.org/bots/api#richblockvideo
@@ -16147,17 +14737,6 @@ type RichBlockVideo struct {
 	Caption *RichBlockCaption `json:"caption,omitempty"`
 }
 
-func (o RichBlockVideo) MarshalJSON() ([]byte, error) {
-	type alias RichBlockVideo
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "video",
-		alias: alias(o),
-	})
-}
-
 // A block with a voice note, corresponding to the HTML tag <audio>.
 //
 // See https://core.telegram.org/bots/api#richblockvoicenote
@@ -16166,17 +14745,6 @@ type RichBlockVoiceNote struct {
 	VoiceNote Voice `json:"voice_note"`
 	// Caption of the block
 	Caption *RichBlockCaption `json:"caption,omitempty"`
-}
-
-func (o RichBlockVoiceNote) MarshalJSON() ([]byte, error) {
-	type alias RichBlockVoiceNote
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "voice_note",
-		alias: alias(o),
-	})
 }
 
 // A block with a “Thinking…” placeholder, corresponding to the custom HTML tag
@@ -16189,17 +14757,6 @@ type RichBlockThinking struct {
 	// Text of the block. See https://t.me/addemoji/AIActions for examples of custom
 	// emoji that are recommended for usage in the block.
 	Text RichText `json:"text"`
-}
-
-func (o RichBlockThinking) MarshalJSON() ([]byte, error) {
-	type alias RichBlockThinking
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "thinking",
-		alias: alias(o),
-	})
 }
 
 func (o *RichBlockThinking) UnmarshalJSON(data []byte) error {
@@ -16238,30 +14795,6 @@ type InputRichBlockListItem struct {
 	// lowercase letters, “A” for uppercase letters, “i” for lowercase Roman
 	// numerals, “I” for uppercase Roman numerals, or “1” for decimal numbers
 	Type *string `json:"type,omitempty"`
-}
-
-func (o *InputRichBlockListItem) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockListItem
-	var aux struct {
-		Blocks []json.RawMessage `json:"blocks"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockListItem(aux.alias)
-	if aux.Blocks != nil {
-		result := make([]InputRichBlock, len(aux.Blocks))
-		for i, raw := range aux.Blocks {
-			v, err := unmarshalInputRichBlock(raw)
-			if err != nil {
-				return err
-			}
-			result[i] = v
-		}
-		o.Blocks = result
-	}
-	return nil
 }
 
 func (o InputRichBlockListItem) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -16315,145 +14848,6 @@ func (InputRichBlockVideo) sealedInputRichBlock() {}
 func (InputRichBlockVoiceNote) sealedInputRichBlock() {}
 func (InputRichBlockThinking) sealedInputRichBlock() {}
 
-func unmarshalInputRichBlock(data []byte) (InputRichBlock, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "paragraph":
-		var variant InputRichBlockParagraph
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "heading":
-		var variant InputRichBlockSectionHeading
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "pre":
-		var variant InputRichBlockPreformatted
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "footer":
-		var variant InputRichBlockFooter
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "divider":
-		var variant InputRichBlockDivider
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "mathematical_expression":
-		var variant InputRichBlockMathematicalExpression
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "anchor":
-		var variant InputRichBlockAnchor
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "list":
-		var variant InputRichBlockList
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "blockquote":
-		var variant InputRichBlockBlockQuotation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "pullquote":
-		var variant InputRichBlockPullQuotation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "collage":
-		var variant InputRichBlockCollage
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "slideshow":
-		var variant InputRichBlockSlideshow
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "table":
-		var variant InputRichBlockTable
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "details":
-		var variant InputRichBlockDetails
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "map":
-		var variant InputRichBlockMap
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "animation":
-		var variant InputRichBlockAnimation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "audio":
-		var variant InputRichBlockAudio
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "photo":
-		var variant InputRichBlockPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputRichBlockVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "voice_note":
-		var variant InputRichBlockVoiceNote
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "thinking":
-		var variant InputRichBlockThinking
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputRichBlock %q", mark.Key)
-	}
-}
-
 // A text paragraph, corresponding to the HTML tag <p>.
 //
 // See https://core.telegram.org/bots/api#inputrichblockparagraph
@@ -16471,26 +14865,6 @@ func (o InputRichBlockParagraph) MarshalJSON() ([]byte, error) {
 		Type: "paragraph",
 		alias: alias(o),
 	})
-}
-
-func (o *InputRichBlockParagraph) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockParagraph
-	var aux struct {
-		Text json.RawMessage `json:"text"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockParagraph(aux.alias)
-	if aux.Text != nil {
-		result, err := unmarshalRichText(aux.Text)
-		if err != nil {
-			return err
-		}
-		o.Text = result
-	}
-	return nil
 }
 
 func (o InputRichBlockParagraph) resolve(_ *fileSink) (json.RawMessage, error) {
@@ -16519,26 +14893,6 @@ func (o InputRichBlockSectionHeading) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputRichBlockSectionHeading) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockSectionHeading
-	var aux struct {
-		Text json.RawMessage `json:"text"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockSectionHeading(aux.alias)
-	if aux.Text != nil {
-		result, err := unmarshalRichText(aux.Text)
-		if err != nil {
-			return err
-		}
-		o.Text = result
-	}
-	return nil
-}
-
 func (o InputRichBlockSectionHeading) resolve(_ *fileSink) (json.RawMessage, error) {
 	return json.Marshal(o)
 }
@@ -16565,26 +14919,6 @@ func (o InputRichBlockPreformatted) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputRichBlockPreformatted) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockPreformatted
-	var aux struct {
-		Text json.RawMessage `json:"text"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockPreformatted(aux.alias)
-	if aux.Text != nil {
-		result, err := unmarshalRichText(aux.Text)
-		if err != nil {
-			return err
-		}
-		o.Text = result
-	}
-	return nil
-}
-
 func (o InputRichBlockPreformatted) resolve(_ *fileSink) (json.RawMessage, error) {
 	return json.Marshal(o)
 }
@@ -16606,26 +14940,6 @@ func (o InputRichBlockFooter) MarshalJSON() ([]byte, error) {
 		Type: "footer",
 		alias: alias(o),
 	})
-}
-
-func (o *InputRichBlockFooter) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockFooter
-	var aux struct {
-		Text json.RawMessage `json:"text"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockFooter(aux.alias)
-	if aux.Text != nil {
-		result, err := unmarshalRichText(aux.Text)
-		if err != nil {
-			return err
-		}
-		o.Text = result
-	}
-	return nil
 }
 
 func (o InputRichBlockFooter) resolve(_ *fileSink) (json.RawMessage, error) {
@@ -16763,38 +15077,6 @@ func (o InputRichBlockBlockQuotation) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputRichBlockBlockQuotation) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockBlockQuotation
-	var aux struct {
-		Blocks []json.RawMessage `json:"blocks"`
-		Credit json.RawMessage `json:"credit"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockBlockQuotation(aux.alias)
-	if aux.Blocks != nil {
-		result := make([]InputRichBlock, len(aux.Blocks))
-		for i, raw := range aux.Blocks {
-			v, err := unmarshalInputRichBlock(raw)
-			if err != nil {
-				return err
-			}
-			result[i] = v
-		}
-		o.Blocks = result
-	}
-	if aux.Credit != nil {
-		result, err := unmarshalRichText(aux.Credit)
-		if err != nil {
-			return err
-		}
-		o.Credit = result
-	}
-	return nil
-}
-
 func (o InputRichBlockBlockQuotation) resolve(sink *fileSink) (json.RawMessage, error) {
 	blocks := make([]json.RawMessage, len(o.Blocks))
 	for i, el := range o.Blocks {
@@ -16838,34 +15120,6 @@ func (o InputRichBlockPullQuotation) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputRichBlockPullQuotation) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockPullQuotation
-	var aux struct {
-		Text json.RawMessage `json:"text"`
-		Credit json.RawMessage `json:"credit"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockPullQuotation(aux.alias)
-	if aux.Text != nil {
-		result, err := unmarshalRichText(aux.Text)
-		if err != nil {
-			return err
-		}
-		o.Text = result
-	}
-	if aux.Credit != nil {
-		result, err := unmarshalRichText(aux.Credit)
-		if err != nil {
-			return err
-		}
-		o.Credit = result
-	}
-	return nil
-}
-
 func (o InputRichBlockPullQuotation) resolve(_ *fileSink) (json.RawMessage, error) {
 	return json.Marshal(o)
 }
@@ -16889,30 +15143,6 @@ func (o InputRichBlockCollage) MarshalJSON() ([]byte, error) {
 		Type: "collage",
 		alias: alias(o),
 	})
-}
-
-func (o *InputRichBlockCollage) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockCollage
-	var aux struct {
-		Blocks []json.RawMessage `json:"blocks"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockCollage(aux.alias)
-	if aux.Blocks != nil {
-		result := make([]InputRichBlock, len(aux.Blocks))
-		for i, raw := range aux.Blocks {
-			v, err := unmarshalInputRichBlock(raw)
-			if err != nil {
-				return err
-			}
-			result[i] = v
-		}
-		o.Blocks = result
-	}
-	return nil
 }
 
 func (o InputRichBlockCollage) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -16955,30 +15185,6 @@ func (o InputRichBlockSlideshow) MarshalJSON() ([]byte, error) {
 		Type: "slideshow",
 		alias: alias(o),
 	})
-}
-
-func (o *InputRichBlockSlideshow) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockSlideshow
-	var aux struct {
-		Blocks []json.RawMessage `json:"blocks"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockSlideshow(aux.alias)
-	if aux.Blocks != nil {
-		result := make([]InputRichBlock, len(aux.Blocks))
-		for i, raw := range aux.Blocks {
-			v, err := unmarshalInputRichBlock(raw)
-			if err != nil {
-				return err
-			}
-			result[i] = v
-		}
-		o.Blocks = result
-	}
-	return nil
 }
 
 func (o InputRichBlockSlideshow) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -17027,26 +15233,6 @@ func (o InputRichBlockTable) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputRichBlockTable) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockTable
-	var aux struct {
-		Caption json.RawMessage `json:"caption"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockTable(aux.alias)
-	if aux.Caption != nil {
-		result, err := unmarshalRichText(aux.Caption)
-		if err != nil {
-			return err
-		}
-		o.Caption = result
-	}
-	return nil
-}
-
 func (o InputRichBlockTable) resolve(_ *fileSink) (json.RawMessage, error) {
 	return json.Marshal(o)
 }
@@ -17073,38 +15259,6 @@ func (o InputRichBlockDetails) MarshalJSON() ([]byte, error) {
 		Type: "details",
 		alias: alias(o),
 	})
-}
-
-func (o *InputRichBlockDetails) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockDetails
-	var aux struct {
-		Summary json.RawMessage `json:"summary"`
-		Blocks []json.RawMessage `json:"blocks"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockDetails(aux.alias)
-	if aux.Summary != nil {
-		result, err := unmarshalRichText(aux.Summary)
-		if err != nil {
-			return err
-		}
-		o.Summary = result
-	}
-	if aux.Blocks != nil {
-		result := make([]InputRichBlock, len(aux.Blocks))
-		for i, raw := range aux.Blocks {
-			v, err := unmarshalInputRichBlock(raw)
-			if err != nil {
-				return err
-			}
-			result[i] = v
-		}
-		o.Blocks = result
-	}
-	return nil
 }
 
 func (o InputRichBlockDetails) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -17374,26 +15528,6 @@ func (o InputRichBlockThinking) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InputRichBlockThinking) UnmarshalJSON(data []byte) error {
-	type alias InputRichBlockThinking
-	var aux struct {
-		Text json.RawMessage `json:"text"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InputRichBlockThinking(aux.alias)
-	if aux.Text != nil {
-		result, err := unmarshalRichText(aux.Text)
-		if err != nil {
-			return err
-		}
-		o.Text = result
-	}
-	return nil
-}
-
 func (o InputRichBlockThinking) resolve(_ *fileSink) (json.RawMessage, error) {
 	return json.Marshal(o)
 }
@@ -17571,26 +15705,6 @@ func (o InlineQueryResultArticle) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultArticle) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultArticle
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultArticle(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultArticle) resolve(sink *fileSink) (json.RawMessage, error) {
 	inputMessageContent, err := o.InputMessageContent.resolve(sink)
 	if err != nil {
@@ -17654,26 +15768,6 @@ func (o InlineQueryResultPhoto) MarshalJSON() ([]byte, error) {
 		Type: "photo",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultPhoto) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultPhoto
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultPhoto(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultPhoto) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -17748,26 +15842,6 @@ func (o InlineQueryResultGif) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultGif) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultGif
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultGif(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultGif) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -17839,26 +15913,6 @@ func (o InlineQueryResultMpeg4Gif) MarshalJSON() ([]byte, error) {
 		Type: "mpeg4_gif",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultMpeg4Gif) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultMpeg4Gif
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultMpeg4Gif(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultMpeg4Gif) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -17939,26 +15993,6 @@ func (o InlineQueryResultVideo) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultVideo) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultVideo
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultVideo(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultVideo) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -18021,26 +16055,6 @@ func (o InlineQueryResultAudio) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultAudio) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultAudio
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultAudio(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultAudio) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -18100,26 +16114,6 @@ func (o InlineQueryResultVoice) MarshalJSON() ([]byte, error) {
 		Type: "voice",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultVoice) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultVoice
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultVoice(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultVoice) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -18192,26 +16186,6 @@ func (o InlineQueryResultDocument) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultDocument) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultDocument
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultDocument(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultDocument) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -18280,26 +16254,6 @@ func (o InlineQueryResultLocation) MarshalJSON() ([]byte, error) {
 		Type: "location",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultLocation) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultLocation
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultLocation(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultLocation) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -18372,26 +16326,6 @@ func (o InlineQueryResultVenue) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultVenue) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultVenue
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultVenue(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultVenue) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -18450,26 +16384,6 @@ func (o InlineQueryResultContact) MarshalJSON() ([]byte, error) {
 		Type: "contact",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultContact) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultContact
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultContact(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultContact) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -18562,26 +16476,6 @@ func (o InlineQueryResultCachedPhoto) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultCachedPhoto) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedPhoto
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedPhoto(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultCachedPhoto) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -18641,26 +16535,6 @@ func (o InlineQueryResultCachedGif) MarshalJSON() ([]byte, error) {
 		Type: "gif",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultCachedGif) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedGif
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedGif(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultCachedGif) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -18726,26 +16600,6 @@ func (o InlineQueryResultCachedMpeg4Gif) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultCachedMpeg4Gif) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedMpeg4Gif
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedMpeg4Gif(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultCachedMpeg4Gif) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -18793,26 +16647,6 @@ func (o InlineQueryResultCachedSticker) MarshalJSON() ([]byte, error) {
 		Type: "sticker",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultCachedSticker) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedSticker
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedSticker(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultCachedSticker) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -18874,26 +16708,6 @@ func (o InlineQueryResultCachedDocument) MarshalJSON() ([]byte, error) {
 		Type: "document",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultCachedDocument) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedDocument
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedDocument(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultCachedDocument) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -18959,26 +16773,6 @@ func (o InlineQueryResultCachedVideo) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultCachedVideo) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedVideo
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedVideo(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultCachedVideo) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -19038,26 +16832,6 @@ func (o InlineQueryResultCachedVoice) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (o *InlineQueryResultCachedVoice) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedVoice
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedVoice(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
-}
-
 func (o InlineQueryResultCachedVoice) resolve(sink *fileSink) (json.RawMessage, error) {
 	var inputMessageContent json.RawMessage
 	if o.InputMessageContent != nil {
@@ -19113,26 +16887,6 @@ func (o InlineQueryResultCachedAudio) MarshalJSON() ([]byte, error) {
 		Type: "audio",
 		alias: alias(o),
 	})
-}
-
-func (o *InlineQueryResultCachedAudio) UnmarshalJSON(data []byte) error {
-	type alias InlineQueryResultCachedAudio
-	var aux struct {
-		InputMessageContent json.RawMessage `json:"input_message_content"`
-		alias
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*o = InlineQueryResultCachedAudio(aux.alias)
-	if aux.InputMessageContent != nil {
-		result, err := unmarshalInputMessageContent(aux.InputMessageContent)
-		if err != nil {
-			return err
-		}
-		o.InputMessageContent = result
-	}
-	return nil
 }
 
 func (o InlineQueryResultCachedAudio) resolve(sink *fileSink) (json.RawMessage, error) {
@@ -20001,17 +17755,6 @@ func unmarshalRevenueWithdrawalState(data []byte) (RevenueWithdrawalState, error
 type RevenueWithdrawalStatePending struct {
 }
 
-func (o RevenueWithdrawalStatePending) MarshalJSON() ([]byte, error) {
-	type alias RevenueWithdrawalStatePending
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "pending",
-		alias: alias(o),
-	})
-}
-
 // The withdrawal succeeded.
 //
 // See https://core.telegram.org/bots/api#revenuewithdrawalstatesucceeded
@@ -20022,32 +17765,10 @@ type RevenueWithdrawalStateSucceeded struct {
 	URL string `json:"url"`
 }
 
-func (o RevenueWithdrawalStateSucceeded) MarshalJSON() ([]byte, error) {
-	type alias RevenueWithdrawalStateSucceeded
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "succeeded",
-		alias: alias(o),
-	})
-}
-
 // The withdrawal failed and the transaction was refunded.
 //
 // See https://core.telegram.org/bots/api#revenuewithdrawalstatefailed
 type RevenueWithdrawalStateFailed struct {
-}
-
-func (o RevenueWithdrawalStateFailed) MarshalJSON() ([]byte, error) {
-	type alias RevenueWithdrawalStateFailed
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "failed",
-		alias: alias(o),
-	})
 }
 
 // Contains information about the affiliate that received a commission via this
@@ -20176,17 +17897,6 @@ type TransactionPartnerUser struct {
 	PremiumSubscriptionDuration *int64 `json:"premium_subscription_duration,omitempty"`
 }
 
-func (o TransactionPartnerUser) MarshalJSON() ([]byte, error) {
-	type alias TransactionPartnerUser
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "user",
-		alias: alias(o),
-	})
-}
-
 func (o *TransactionPartnerUser) UnmarshalJSON(data []byte) error {
 	type alias TransactionPartnerUser
 	var aux struct {
@@ -20221,17 +17931,6 @@ type TransactionPartnerChat struct {
 	Gift *Gift `json:"gift,omitempty"`
 }
 
-func (o TransactionPartnerChat) MarshalJSON() ([]byte, error) {
-	type alias TransactionPartnerChat
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "chat",
-		alias: alias(o),
-	})
-}
-
 // Describes the affiliate program that issued the affiliate commission received
 // via this transaction.
 //
@@ -20244,34 +17943,12 @@ type TransactionPartnerAffiliateProgram struct {
 	SponsorUser *User `json:"sponsor_user,omitempty"`
 }
 
-func (o TransactionPartnerAffiliateProgram) MarshalJSON() ([]byte, error) {
-	type alias TransactionPartnerAffiliateProgram
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "affiliate_program",
-		alias: alias(o),
-	})
-}
-
 // Describes a withdrawal transaction with Fragment.
 //
 // See https://core.telegram.org/bots/api#transactionpartnerfragment
 type TransactionPartnerFragment struct {
 	// State of the transaction if the transaction is outgoing
 	WithdrawalState RevenueWithdrawalState `json:"withdrawal_state,omitempty"`
-}
-
-func (o TransactionPartnerFragment) MarshalJSON() ([]byte, error) {
-	type alias TransactionPartnerFragment
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "fragment",
-		alias: alias(o),
-	})
 }
 
 func (o *TransactionPartnerFragment) UnmarshalJSON(data []byte) error {
@@ -20300,17 +17977,6 @@ func (o *TransactionPartnerFragment) UnmarshalJSON(data []byte) error {
 type TransactionPartnerTelegramAds struct {
 }
 
-func (o TransactionPartnerTelegramAds) MarshalJSON() ([]byte, error) {
-	type alias TransactionPartnerTelegramAds
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "telegram_ads",
-		alias: alias(o),
-	})
-}
-
 // Describes a transaction with payment for paid broadcasting.
 //
 // See https://core.telegram.org/bots/api#transactionpartnertelegramapi
@@ -20320,32 +17986,10 @@ type TransactionPartnerTelegramAPI struct {
 	RequestCount int64 `json:"request_count"`
 }
 
-func (o TransactionPartnerTelegramAPI) MarshalJSON() ([]byte, error) {
-	type alias TransactionPartnerTelegramAPI
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "telegram_api",
-		alias: alias(o),
-	})
-}
-
 // Describes a transaction with an unknown source or recipient.
 //
 // See https://core.telegram.org/bots/api#transactionpartnerother
 type TransactionPartnerOther struct {
-}
-
-func (o TransactionPartnerOther) MarshalJSON() ([]byte, error) {
-	type alias TransactionPartnerOther
-	return json.Marshal(struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type: "other",
-		alias: alias(o),
-	})
 }
 
 // Describes a Telegram Star transaction. Note that if the buyer initiates a
@@ -20552,73 +18196,6 @@ func (PassportElementErrorFiles) sealedPassportElementError() {}
 func (PassportElementErrorTranslationFile) sealedPassportElementError() {}
 func (PassportElementErrorTranslationFiles) sealedPassportElementError() {}
 func (PassportElementErrorUnspecified) sealedPassportElementError() {}
-
-func unmarshalPassportElementError(data []byte) (PassportElementError, error) {
-	var mark struct {
-		Key string `json:"source"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "data":
-		var variant PassportElementErrorDataField
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "front_side":
-		var variant PassportElementErrorFrontSide
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "reverse_side":
-		var variant PassportElementErrorReverseSide
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "selfie":
-		var variant PassportElementErrorSelfie
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "file":
-		var variant PassportElementErrorFile
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "files":
-		var variant PassportElementErrorFiles
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "translation_file":
-		var variant PassportElementErrorTranslationFile
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "translation_files":
-		var variant PassportElementErrorTranslationFiles
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "unspecified":
-		var variant PassportElementErrorUnspecified
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown PassportElementError %q", mark.Key)
-	}
-}
 
 // Represents an issue in one of the data fields that was provided by the user.
 // The error is considered resolved when the field's value changes.
@@ -21080,49 +18657,6 @@ func (InputMediaLivePhoto) sealedInputMediaGroup() {}
 func (InputMediaPhoto) sealedInputMediaGroup() {}
 func (InputMediaVideo) sealedInputMediaGroup() {}
 
-func unmarshalInputMediaGroup(data []byte) (InputMediaGroup, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "audio":
-		var variant InputMediaAudio
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "document":
-		var variant InputMediaDocument
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "live_photo":
-		var variant InputMediaLivePhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "photo":
-		var variant InputMediaPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputMediaVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputMediaGroup %q", mark.Key)
-	}
-}
-
 // InputRichMedia represents a media element embedded in a rich message.
 //sumtype:decl
 type InputRichMedia interface {
@@ -21135,49 +18669,6 @@ func (InputMediaAudio) sealedInputRichMedia() {}
 func (InputMediaPhoto) sealedInputRichMedia() {}
 func (InputMediaVideo) sealedInputRichMedia() {}
 func (InputMediaVoiceNote) sealedInputRichMedia() {}
-
-func unmarshalInputRichMedia(data []byte) (InputRichMedia, error) {
-	var mark struct {
-		Key string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &mark); err != nil {
-		return nil, err
-	}
-	switch mark.Key {
-	case "animation":
-		var variant InputMediaAnimation
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "audio":
-		var variant InputMediaAudio
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "photo":
-		var variant InputMediaPhoto
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "video":
-		var variant InputMediaVideo
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	case "voice_note":
-		var variant InputMediaVoiceNote
-		if err := json.Unmarshal(data, &variant); err != nil {
-			return nil, err
-		}
-		return variant, nil
-	default:
-		return nil, fmt.Errorf("unknown InputRichMedia %q", mark.Key)
-	}
-}
 
 // InputFile represents a file to send, either by file ID or by uploading.
 //sumtype:decl

--- a/targets/golangv2/alias.go
+++ b/targets/golangv2/alias.go
@@ -43,3 +43,9 @@ func (a Alias) Name() string {
 func (a Alias) Type() string {
 	return NewRequiredType(a.inner.Type).Value()
 }
+
+// Direction returns which way the alias travels. The declaration itself is the
+// same either way; what a block written by hand puts beside it is not.
+func (a Alias) Direction() Direction {
+	return NewDirection(a.inner.Direction)
+}

--- a/targets/golangv2/direction.go
+++ b/targets/golangv2/direction.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package golangv2
+
+import "github.com/andreychh/tgen/model"
+
+// Direction is which way a declaration travels, read as what has to be written
+// for it. A declaration travelling one way needs the half of the codec that way
+// calls for and no more, since nothing encodes a value no request ever carries
+// and nothing decodes one no response ever carries.
+type Direction struct {
+	inner model.Direction
+}
+
+// NewDirection creates a Direction from the way a declaration travels.
+func NewDirection(direction model.Direction) Direction {
+	return Direction{inner: direction}
+}
+
+// Sent reports whether a request ever carries the declaration, which is what
+// obliges it to write itself into JSON. One travelling both ways is sent no
+// less than one travelling outbound alone.
+func (d Direction) Sent() bool {
+	return d.inner == model.DirectionOutbound || d.inner == model.DirectionBidirectional
+}
+
+// Received reports whether a response ever carries the declaration, which is
+// what obliges it to read itself out of JSON. One travelling both ways is
+// received no less than one travelling inbound alone.
+func (d Direction) Received() bool {
+	return d.inner == model.DirectionInbound || d.inner == model.DirectionBidirectional
+}

--- a/targets/golangv2/discriminated_object.go
+++ b/targets/golangv2/discriminated_object.go
@@ -72,3 +72,10 @@ func (o DiscriminatedObject) Rewrites() bool {
 func (o DiscriminatedObject) Discriminator() Discriminator {
 	return NewDiscriminator(o.inner.Discriminator)
 }
+
+// Direction returns which way the object travels, which is what decides the
+// half of the codec it has to declare. An object no request carries never
+// writes the value telling it apart, however plainly it is told apart.
+func (o DiscriminatedObject) Direction() Direction {
+	return NewDirection(o.inner.Direction)
+}

--- a/targets/golangv2/object.go
+++ b/targets/golangv2/object.go
@@ -63,3 +63,9 @@ func (o Object) Files() []Attached {
 func (o Object) Rewrites() bool {
 	return o.inner.Rewrites
 }
+
+// Direction returns which way the object travels, which is what decides the
+// half of the codec it has to declare.
+func (o Object) Direction() Direction {
+	return NewDirection(o.inner.Direction)
+}

--- a/targets/golangv2/templates/manual.tmpl
+++ b/targets/golangv2/templates/manual.tmpl
@@ -12,6 +12,17 @@
 	its own beside it. Spelling a declaration out in full here would freeze
 	what the specification still owns, and the next release would drift past it
 	unnoticed.
+
+	Every block pins the way its definition travels, whether or not it writes
+	anything for either way of travelling. A block is written knowing which way
+	the thing goes — one only ever sent needs no decoder, one only ever received
+	needs nothing that hands a file over — and that knowledge lives nowhere a
+	release can check it. Pinning it turns a drift into a stopped generation and
+	a person reading the block again.
+
+	The pin says what moved and not what to do about it. What a changed
+	direction costs a block is exactly what nobody can know before reading it,
+	and a message guessing at it would be one more claim no release checks.
 */}}
 
 {{- /*
@@ -20,6 +31,7 @@
 	never uploaded, so it stays in the body wherever it sits.
 */}}
 {{- define "manual_fileid"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Alias*/}}
+{{- assert (and .Direction.Sent (not .Direction.Received)) "FileID no longer travels outbound"}}
 {{- template "alias" .}}
 
 func (f {{.Name}}) place(_ *fileSink, _ string) *string {
@@ -41,6 +53,7 @@ func (f {{.Name}}) attach(_ *fileSink) string {
 	leaves the reference the part is reached by.
 */}}
 {{- define "manual_upload"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Object*/}}
+{{- assert (and .Direction.Sent (not .Direction.Received)) "Upload no longer travels outbound"}}
 {{.Doc}}
 type {{.Name}} struct {
 	Name   string
@@ -67,11 +80,13 @@ func (u {{.Name}}) name() string {
 {{- /*
 	manual_inputfile writes the union a file travels as. Its interface is the one
 	thing about a union no shape can write: the two ways of travelling are tgen's
-	invention, and every generated method reaching a file leans on them. Inbound,
-	only a file id can ever come back — an upload is a stream of bytes going one
-	way — so the decoder reads the reference and nothing else.
+	invention, and every generated method reaching a file leans on them. A file
+	only ever goes out, so nothing here reads one back: an upload is a stream of
+	bytes going one way, and a file id comes back as the string it is, under the
+	name the response gives it and not as this union.
 */}}
 {{- define "manual_inputfile"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- assert (and .Direction.Sent (not .Direction.Received)) "InputFile no longer travels outbound"}}
 {{- $union := .Name}}
 {{.Doc}}
 //sumtype:decl
@@ -83,35 +98,18 @@ type {{$union}} interface {
 {{range .Variants}}
 func ({{.Name}}) sealed{{$union}}() {}
 {{- end}}
-
-func unmarshal{{$union}}(data []byte) ({{$union}}, error) {
-	var id FileID
-	if err := json.Unmarshal(data, &id); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal %s into {{$union}}: %w", data, err)
-	}
-	return id, nil
-}
 {{- end}}
 
 {{- /*
-	manual_chatid writes the decoder of the union a chat is addressed by. The two
-	variants are told apart by what JSON they are: a number is an id, a string is
-	a username, and neither decodes as the other.
+	manual_chatid claims the union a chat is addressed by, and writes nothing
+	beyond the shape. A chat is only ever addressed, never reported as this
+	union, so no payload is read back into it. Were one to be, the two variants
+	would tell themselves apart by what JSON they are — a number is an id, a
+	string is a username, and neither decodes as the other.
 */}}
 {{- define "manual_chatid"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- assert (and .Direction.Sent (not .Direction.Received)) "ChatID no longer travels outbound"}}
 {{- template "union" .}}
-
-func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
-	var id ID
-	if json.Unmarshal(data, &id) == nil {
-		return id, nil
-	}
-	var username Username
-	if json.Unmarshal(data, &username) == nil {
-		return username, nil
-	}
-	return nil, fmt.Errorf("cannot unmarshal %s into {{.Name}}", data)
-}
 {{- end}}
 
 {{- /*
@@ -121,6 +119,7 @@ func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
 	never as an object, so trying them in turn tells them apart.
 */}}
 {{- define "manual_maybemessage"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- assert (and (not .Direction.Sent) .Direction.Received) "MaybeMessage no longer travels inbound"}}
 {{- template "union" .}}
 
 func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
@@ -143,6 +142,7 @@ func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
 	instead: an inaccessible message always dates from zero.
 */}}
 {{- define "manual_maybeinaccessiblemessage"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- assert (and (not .Direction.Sent) .Direction.Received) "MaybeInaccessibleMessage no longer travels inbound"}}
 {{- template "union" .}}
 
 func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
@@ -168,19 +168,17 @@ func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
 {{- end}}
 
 {{- /*
-	manual_inputmessagecontent writes the decoder of a union that is only ever
-	sent. Nothing tells its six variants apart: no key marks them, and every one
-	of them is an object, so trying them in turn would let the first swallow the
-	rest. Nothing has to tell them apart either — an inline result travels one way,
-	and the decoder exists only because an object holding one is declared with a
-	decoder of its own. It says so instead of guessing.
+	manual_inputmessagecontent claims a union that is only ever sent, and writes
+	nothing beyond the shape. Nothing tells its six variants apart: no key marks
+	them, and every one of them is an object, so trying them in turn would let
+	the first swallow the rest. Nothing has to tell them apart either — an inline
+	result travels one way. This block once wrote a decoder that only ever
+	refused, because an object holding one was declared with a decoder of its
+	own; that object is only ever sent too, and is declared without one now.
 */}}
 {{- define "manual_inputmessagecontent"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- assert (and .Direction.Sent (not .Direction.Received)) "InputMessageContent no longer travels outbound"}}
 {{- template "union" .}}
-
-func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
-	return nil, fmt.Errorf("{{.Name}} is only ever sent, so %s cannot be read back", data)
-}
 {{- end}}
 
 {{- /*
@@ -196,6 +194,7 @@ func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
 	marks of the variants that do carry them.
 */}}
 {{- define "manual_richtext"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
+{{- assert (and .Direction.Sent .Direction.Received) "RichText no longer travels both ways"}}
 {{- template "union" .}}
 
 func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {

--- a/targets/golangv2/templates/types.tmpl
+++ b/targets/golangv2/templates/types.tmpl
@@ -20,7 +20,7 @@ type {{.Name}} struct {
 
 {{- define "object"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Object*/}}
 {{- template "struct" .}}
-{{- if .Unions}}
+{{- if and .Direction.Received .Unions}}
 {{template "unmarshal_object" .}}
 {{- end}}
 {{- if .Files}}
@@ -32,6 +32,7 @@ type {{.Name}} struct {
 
 {{- define "discriminated_object"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.DiscriminatedObject*/}}
 {{- template "struct" .}}
+{{- if .Direction.Sent}}
 
 func (o {{.Name}}) MarshalJSON() ([]byte, error) {
 	type alias {{.Name}}
@@ -47,7 +48,8 @@ func (o {{.Name}}) MarshalJSON() ([]byte, error) {
 		alias: alias(o),
 	})
 }
-{{- if .Unions}}
+{{- end}}
+{{- if and .Direction.Received .Unions}}
 {{template "unmarshal_object" .}}
 {{- end}}
 {{- if .Files}}

--- a/targets/golangv2/templates/union.tmpl
+++ b/targets/golangv2/templates/union.tmpl
@@ -54,6 +54,7 @@ type {{$union}} interface{ sealed{{$union}}() }
 {{range .Variants}}
 func ({{.Name}}) sealed{{$union}}() {}
 {{- end}}
+{{- if .Direction.Received}}
 
 func unmarshal{{$union}}(data []byte) ({{$union}}, error) {
 	var mark struct {
@@ -75,4 +76,5 @@ func unmarshal{{$union}}(data []byte) ({{$union}}, error) {
 		return nil, fmt.Errorf("unknown {{$union}} %q", mark.Key)
 	}
 }
+{{- end}}
 {{- end}}

--- a/targets/golangv2/union.go
+++ b/targets/golangv2/union.go
@@ -58,6 +58,13 @@ func (u Union) Variants() []Variant {
 	return slices.NewMapped(u.inner.Variants, NewVariant)
 }
 
+// Direction returns which way the union travels. The interface and the markers
+// are the same either way; the decoder written by hand for this reference is
+// what the direction decides the need for.
+func (u Union) Direction() Direction {
+	return NewDirection(u.inner.Direction)
+}
+
 // Variant represents the Go declaration of one variant of a union: the marker
 // tying the type it names to the interface.
 type Variant struct {
@@ -75,8 +82,9 @@ func (v Variant) Name() string {
 }
 
 // DiscriminatedUnion represents the Go declaration of a union one key tells
-// every variant of apart: the interface, the marker each variant carries, and
-// the decoder reading that key off the payload to pick one.
+// every variant of apart: the interface, the marker each variant carries, and —
+// when a response ever carries the union — the decoder reading that key off the
+// payload to pick one.
 type DiscriminatedUnion struct {
 	inner ir.DiscriminatedUnion
 }
@@ -124,6 +132,13 @@ func (u DiscriminatedUnion) Carrier() bool {
 // documentation listed them.
 func (u DiscriminatedUnion) Variants() []DiscriminatedVariant {
 	return slices.NewMapped(u.inner.Variants, NewDiscriminatedVariant)
+}
+
+// Direction returns which way the union travels, which is what decides whether
+// the decoder is declared at all: a union no response ever carries is never
+// read, however plainly the key tells its variants apart.
+func (u DiscriminatedUnion) Direction() Direction {
+	return NewDirection(u.inner.Direction)
 }
 
 // DiscriminatedVariant represents the Go declaration of one variant of a


### PR DESCRIPTION
This PR adds a `directed` pass that decides which way every definition but a method travels — into a request, out of a response, or both — and reads that in `targets/golangv2` to leave out every `MarshalJSON`, `UnmarshalJSON`, and union decoder nothing can reach, which takes 2551 lines out of `stands/gov2/api/api.go`.

A `Rule` names no direction of its own: it answers bare source-to-target pairs through `Edges`, and only the spread carries a `Reach` along an edge, so the merge lives in one place and no rule can invent a direction an edge never carried.

Blocks written by hand in `manual.tmpl` pin the direction they assume through a new `assert` template function rather than rendering conditionally: a condition can drop what stopped being needed, but it cannot supply what started being needed, so a direction that moves stops the generation and sends a person back to the block. Dropping the generated decoders also orphaned three hand-written ones — `unmarshalChatID`, `unmarshalInputFile`, and `unmarshalInputMessageContent` — which go too.

Closes #96