### PR TITLE
Cover the `gov2` stand with tests and dispatch the marked `RichText` variants

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -250,11 +250,12 @@ tasks:
       - mise run test
 
   stands:check:gov2:
-    desc: Verify the generated nanopass Go code compiles
+    desc: Verify the generated nanopass Go code compiles and tests pass
     dir: stands/gov2
     cmds:
       - mise trust --quiet
       - mise run check
+      - mise run test
 
   stands:check:python:
     desc: Verify the generated Python code passes type checking

--- a/stands/gov2/api/api.go
+++ b/stands/gov2/api/api.go
@@ -13024,7 +13024,166 @@ func unmarshalRichText(data []byte) (RichText, error) {
 		}
 		return sequence, nil
 	}
-	return nil, fmt.Errorf("cannot unmarshal %s into RichText: the marked variants are not dispatched yet", data)
+	var mark struct {
+		Key string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &mark); err != nil {
+		return nil, err
+	}
+	switch mark.Key {
+	case "bold":
+		var variant RichTextBold
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "italic":
+		var variant RichTextItalic
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "underline":
+		var variant RichTextUnderline
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "strikethrough":
+		var variant RichTextStrikethrough
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "spoiler":
+		var variant RichTextSpoiler
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "date_time":
+		var variant RichTextDateTime
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "text_mention":
+		var variant RichTextTextMention
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "subscript":
+		var variant RichTextSubscript
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "superscript":
+		var variant RichTextSuperscript
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "marked":
+		var variant RichTextMarked
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "code":
+		var variant RichTextCode
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "custom_emoji":
+		var variant RichTextCustomEmoji
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "mathematical_expression":
+		var variant RichTextMathematicalExpression
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "url":
+		var variant RichTextURL
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "email_address":
+		var variant RichTextEmailAddress
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "phone_number":
+		var variant RichTextPhoneNumber
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "bank_card_number":
+		var variant RichTextBankCardNumber
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "mention":
+		var variant RichTextMention
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "hashtag":
+		var variant RichTextHashtag
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "cashtag":
+		var variant RichTextCashtag
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "bot_command":
+		var variant RichTextBotCommand
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "anchor":
+		var variant RichTextAnchor
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "anchor_link":
+		var variant RichTextAnchorLink
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "reference":
+		var variant RichTextReference
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "reference_link":
+		var variant RichTextReferenceLink
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	default:
+		return nil, fmt.Errorf("unknown RichText %q", mark.Key)
+	}
 }
 
 // A bold text.

--- a/stands/gov2/api/capture_test.go
+++ b/stands/gov2/api/capture_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"stand/api"
+)
+
+// CapturingConnection implements [api.Connection] by materializing a payload
+// into the request it would have been sent as, and keeping that request instead
+// of sending it. It reports no failure and leaves the response untouched, so a
+// call through it observes nothing but what it asked to be sent.
+type CapturingConnection struct {
+	request *http.Request
+}
+
+// NewCapturingConnection creates a CapturingConnection holding no request yet.
+func NewCapturingConnection() *CapturingConnection {
+	return &CapturingConnection{request: nil}
+}
+
+// Do materializes payload into a request and keeps it. It returns an error when
+// the payload cannot become one.
+func (c *CapturingConnection) Do(ctx context.Context, _ api.Method, payload api.Payload, _ any) error {
+	req, err := payload.Request(ctx, http.MethodPost, "http://capture")
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	c.request = req
+	return nil
+}
+
+// Request returns the request the last call was materialized into, or nil when
+// no call has been made.
+func (c *CapturingConnection) Request() *http.Request {
+	return c.request
+}

--- a/stands/gov2/api/client_test.go
+++ b/stands/gov2/api/client_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stand/api"
+)
+
+func TestHTTPConnection_Do(t *testing.T) {
+	cases := []struct {
+		name        string
+		destination func(base, token string) api.Destination
+		body        string
+		closed      bool
+		check       func(*testing.T, string, api.User, error)
+	}{
+		{
+			name:        "posts to the path the token and the method name make",
+			destination: api.NewDestination,
+			body:        `{"ok":true,"result":{"id":7,"is_bot":true,"first_name":"бот"}}`,
+			check: func(t *testing.T, path string, _ api.User, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, "/bot42:XYZ/getMe", path, "a request must reach the endpoint the token and the method name address")
+			},
+		},
+		{
+			name:        "posts under a segment of its own in the test environment",
+			destination: api.NewTestDestination,
+			body:        `{"ok":true,"result":{"id":7,"is_bot":true,"first_name":"бот"}}`,
+			check: func(t *testing.T, path string, _ api.User, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, "/bot42:XYZ/test/getMe", path, "the test environment must be addressed by an extra segment after the token")
+			},
+		},
+		{
+			name:        "hands back what the envelope carried as its result",
+			destination: api.NewDestination,
+			body:        `{"ok":true,"result":{"id":7,"is_bot":true,"first_name":"бот"}}`,
+			check: func(t *testing.T, _ string, user api.User, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, api.User{ID: 7, IsBot: true, FirstName: "бот"}, user, "the result of an envelope reporting success must be decoded into what the method returns")
+			},
+		},
+		{
+			name:        "reports a refusal as the failure the API described",
+			destination: api.NewDestination,
+			body:        `{"ok":false,"error_code":429,"description":"Too Many Requests","parameters":{"retry_after":30}}`,
+			check: func(t *testing.T, _ string, _ api.User, err error) {
+				t.Helper()
+				var failure *api.Error
+				require.ErrorAs(t, err, &failure)
+				require.NotNil(t, failure.Parameters, "a refusal carrying parameters must keep them")
+				assert.Equal(t, int64(30), *failure.Parameters.RetryAfter, "a refusal must carry back what the API said about retrying")
+			},
+		},
+		{
+			name:        "fills in what a refusal left unsaid",
+			destination: api.NewDestination,
+			body:        `{"ok":false}`,
+			check: func(t *testing.T, _ string, _ api.User, err error) {
+				t.Helper()
+				assert.EqualError(t, err, "telegram 0: <no description>", "a refusal saying nothing must still read as a refusal, not as an empty one")
+			},
+		},
+		{
+			name:        "refuses a body that is no envelope",
+			destination: api.NewDestination,
+			body:        `не json`,
+			check: func(t *testing.T, _ string, _ api.User, err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, "decoding envelope", "a body that is no envelope must fail as one, naming what could not be read")
+			},
+		},
+		{
+			name:        "reports a request that never reached the API",
+			destination: api.NewDestination,
+			body:        `{"ok":true,"result":{}}`,
+			closed:      true,
+			check: func(t *testing.T, _ string, _ api.User, err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, "sending request", "a request that never left must fail as a request, not as a refusal of the API")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := ""
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				path = r.URL.Path
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+			if tc.closed {
+				server.Close()
+			}
+			conn := api.NewHTTPConnectionTo(server.Client(), tc.destination(server.URL, "42:XYZ"))
+			user, err := api.GetMeMethod{}.Call(context.Background(), conn)
+			tc.check(t, path, user, err)
+		})
+	}
+}

--- a/stands/gov2/api/files_test.go
+++ b/stands/gov2/api/files_test.go
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stand/api"
+)
+
+func TestSendPhotoMethod_Call(t *testing.T) {
+	cases := []struct {
+		name   string
+		chatID api.ChatID
+		photo  api.InputFile
+		check  func(*testing.T, *http.Request)
+	}{
+		{
+			name:   "sends an upload as a part of its own",
+			chatID: api.ID(-1001234567890),
+			photo:  api.Upload{Name: "морской ёж.jpg", Reader: strings.NewReader("🐙")},
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				file, ok := requireForm(t, req).File("photo")
+				require.True(t, ok, "a parameter that is a file must travel as a part named by the parameter's own key")
+				assert.Equal(
+					t,
+					FormFile{Name: "морской ёж.jpg", Content: "🐙"},
+					file,
+					"a part must carry the bytes of the upload under the name the upload travels as",
+				)
+			},
+		},
+		{
+			name:   "leaves nothing behind in the body for an upload",
+			chatID: api.ID(-1001234567890),
+			photo:  api.Upload{Name: "морской ёж.jpg", Reader: strings.NewReader("🐙")},
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				_, ok := requireForm(t, req).Field("photo")
+				assert.False(t, ok, "an upload handed over to a part of its own must leave no value in the body")
+			},
+		},
+		{
+			name:   "keeps the parameters that are not files in the body",
+			chatID: api.ID(-1001234567890),
+			photo:  api.Upload{Name: "морской ёж.jpg", Reader: strings.NewReader("🐙")},
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				value, ok := requireForm(t, req).Field("chat_id")
+				require.True(t, ok, "a parameter that is not a file must ride in the body of the same request")
+				assert.Equal(t, "-1001234567890", value, "a numeric parameter must ride in the body as the number it is")
+			},
+		},
+		{
+			name:   "keeps a file id in the body as a value of its own",
+			chatID: api.ID(-1001234567890),
+			photo:  api.FileID("AgACAgIAAxkBAAIBY2Vw"),
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.JSONEq(
+					t,
+					`{"chat_id":-1001234567890,"photo":"AgACAgIAAxkBAAIBY2Vw"}`,
+					string(body),
+					"a file already held by Telegram must ride in the body as the name it is known by, attaching nothing to the request",
+				)
+			},
+		},
+		{
+			name:   "addresses a chat by username as the bare string a username is",
+			chatID: api.Username("@ёжики"),
+			photo:  api.Upload{Name: "морской ёж.jpg", Reader: strings.NewReader("🐙")},
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				value, ok := requireForm(t, req).Field("chat_id")
+				require.True(t, ok, "a parameter that is not a file must ride in the body of the same request")
+				assert.Equal(t, "@ёжики", value, "a textual parameter must ride in the body unquoted, as the form field it became")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			_, err := api.SendPhotoMethod{
+				ChatID: tc.chatID,
+				Photo:  tc.photo,
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			tc.check(t, conn.Request())
+		})
+	}
+}
+
+func TestSendMediaGroupMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		media []api.InputMediaGroup
+		check func(*testing.T, Form)
+	}{
+		{
+			name: "attaches a nested upload as the part its reference names",
+			media: []api.InputMediaGroup{
+				api.InputMediaPhoto{Media: api.Upload{Name: "кот.jpg", Reader: strings.NewReader("JPEG")}},
+			},
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				file, ok := form.File("attachment_0")
+				require.True(t, ok, "a file referenced as attach:// must be attached under the key the reference names")
+				assert.Equal(
+					t,
+					FormFile{Name: "кот.jpg", Content: "JPEG"},
+					file,
+					"a part must carry the bytes of the upload under the name the upload travels as",
+				)
+			},
+		},
+		{
+			name: "numbers the attachments of one request in turn",
+			media: []api.InputMediaGroup{
+				api.InputMediaPhoto{Media: api.Upload{Name: "кот.jpg", Reader: strings.NewReader("JPEG")}},
+				api.InputMediaPhoto{Media: api.Upload{Name: "пёс.jpg", Reader: strings.NewReader("JFIF")}},
+			},
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				assert.Equal(
+					t,
+					[]string{"attachment_0", "attachment_1"},
+					form.Attached(),
+					"every file of one request must reach a key of its own, numbered as the request is walked",
+				)
+			},
+		},
+		{
+			name: "points every variant at the part its own upload became",
+			media: []api.InputMediaGroup{
+				api.InputMediaPhoto{Media: api.Upload{Name: "кот.jpg", Reader: strings.NewReader("JPEG")}},
+				api.InputMediaPhoto{Media: api.Upload{Name: "пёс.jpg", Reader: strings.NewReader("JFIF")}},
+			},
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				value, ok := form.Field("media")
+				require.True(t, ok, "a parameter holding files inside must ride in the body as a value of its own")
+				assert.JSONEq(
+					t,
+					`[{"type":"photo","media":"attach://attachment_0"},{"type":"photo","media":"attach://attachment_1"}]`,
+					value,
+					"each element of a sequence must reference the part its own file was attached as, keeping the discriminator its marshaller would have written",
+				)
+			},
+		},
+		{
+			name: "leaves out an optional nested file that was not given",
+			media: []api.InputMediaGroup{
+				api.InputMediaVideo{Media: api.Upload{Name: "ролик.mp4", Reader: strings.NewReader("ftyp")}},
+			},
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				value, ok := form.Field("media")
+				require.True(t, ok, "a parameter holding files inside must ride in the body as a value of its own")
+				assert.JSONEq(
+					t,
+					`[{"type":"video","media":"attach://attachment_0"}]`,
+					value,
+					"an optional file left unset must leave no reference behind, not even an empty one",
+				)
+			},
+		},
+		{
+			name: "hands over an optional nested file once it is given",
+			media: []api.InputMediaGroup{
+				api.InputMediaVideo{
+					Media:     api.Upload{Name: "ролик.mp4", Reader: strings.NewReader("ftyp")},
+					Thumbnail: api.Upload{Name: "кадр.png", Reader: strings.NewReader("\x89PNG")},
+				},
+			},
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				value, ok := form.Field("media")
+				require.True(t, ok, "a parameter holding files inside must ride in the body as a value of its own")
+				assert.JSONEq(
+					t,
+					`[{"type":"video","media":"attach://attachment_0","thumbnail":"attach://attachment_1"}]`,
+					value,
+					"an optional file given inside a variant must reach a part of its own, referenced beside the required one",
+				)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			_, err := api.SendMediaGroupMethod{
+				ChatID: api.ID(-1001234567890),
+				Media:  tc.media,
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			tc.check(t, requireForm(t, conn.Request()))
+		})
+	}
+}
+
+func TestSetMyProfilePhotoMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		photo api.InputProfilePhoto
+		check func(*testing.T, *http.Request)
+	}{
+		{
+			name:  "rewrites a parameter holding an upload into a reference to the part",
+			photo: api.InputProfilePhotoStatic{Photo: api.Upload{Name: "аватар.jpg", Reader: strings.NewReader("JPEG")}},
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				value, ok := requireForm(t, req).Field("photo")
+				require.True(t, ok, "a parameter holding a file inside must ride in the body as a value of its own")
+				assert.JSONEq(
+					t,
+					`{"type":"static","photo":"attach://attachment_0"}`,
+					value,
+					"a parameter holding a file must rewrite itself into JSON referencing the part its file became",
+				)
+			},
+		},
+		{
+			name:  "keeps a file id held inside a parameter as the name it is known by",
+			photo: api.InputProfilePhotoStatic{Photo: api.FileID("AgACAgIAAxkBAAIBY2Vw")},
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.JSONEq(
+					t,
+					`{"photo":{"type":"static","photo":"AgACAgIAAxkBAAIBY2Vw"}}`,
+					string(body),
+					"a file already held by Telegram must be named where it stands, attaching nothing to the request",
+				)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			err := api.SetMyProfilePhotoMethod{Photo: tc.photo}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			tc.check(t, conn.Request())
+		})
+	}
+}
+
+func TestSendPollMethod_Call(t *testing.T) {
+	cases := []struct {
+		name    string
+		options []api.InputPollOption
+		media   api.InputPollMedia
+		check   func(*testing.T, *http.Request)
+	}{
+		{
+			name:    "leaves out an optional parameter that was not given",
+			options: []api.InputPollOption{{Text: "да"}, {Text: "нет"}},
+			media:   nil,
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.JSONEq(
+					t,
+					`{"chat_id":-1001234567890,"question":"обед?","options":[{"text":"да"},{"text":"нет"}]}`,
+					string(body),
+					"an optional parameter that could have held a file must leave the body untouched when it is not given",
+				)
+			},
+		},
+		{
+			name:    "rewrites an optional parameter holding an upload once it is given",
+			options: []api.InputPollOption{{Text: "да"}, {Text: "нет"}},
+			media:   api.InputMediaPhoto{Media: api.Upload{Name: "меню.jpg", Reader: strings.NewReader("JPEG")}},
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				value, ok := requireForm(t, req).Field("explanation_media")
+				require.True(t, ok, "an optional parameter holding a file must ride in the body as a value of its own once it is given")
+				assert.JSONEq(
+					t,
+					`{"type":"photo","media":"attach://attachment_0"}`,
+					value,
+					"an optional parameter holding a file must rewrite itself into JSON referencing the part its file became",
+				)
+			},
+		},
+		{
+			name: "rewrites an element that holds a file, telling it apart by nothing",
+			options: []api.InputPollOption{
+				{Text: "да", Media: api.InputMediaPhoto{Media: api.Upload{Name: "меню.jpg", Reader: strings.NewReader("JPEG")}}},
+				{Text: "нет"},
+			},
+			media: nil,
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				value, ok := requireForm(t, req).Field("options")
+				require.True(t, ok, "a parameter holding files inside must ride in the body as a value of its own")
+				assert.JSONEq(
+					t,
+					`[{"text":"да","media":{"type":"photo","media":"attach://attachment_0"}},{"text":"нет"}]`,
+					value,
+					"an object no discriminator tells apart must rewrite itself carrying its own fields alone, the file inside it handed over on the way",
+				)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			_, err := api.SendPollMethod{
+				ChatID:           api.ID(-1001234567890),
+				Question:         "обед?",
+				Options:          tc.options,
+				ExplanationMedia: tc.media,
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			tc.check(t, conn.Request())
+		})
+	}
+}
+
+func TestAnswerInlineQueryMethod_Call(t *testing.T) {
+	cases := []struct {
+		name    string
+		results []api.InlineQueryResult
+		want    string
+	}{
+		{
+			name: "marshals a variant that holds no file, discriminator and all",
+			results: []api.InlineQueryResult{
+				api.InlineQueryResultGame{ID: "r1", GameShortName: "тетрис"},
+			},
+			want: `{"inline_query_id":"q1","results":[{"type":"game","id":"r1","game_short_name":"тетрис"}]}`,
+		},
+		{
+			name:    "sends an empty sequence as one, not as nothing",
+			results: []api.InlineQueryResult{},
+			want:    `{"inline_query_id":"q1","results":[]}`,
+		},
+		{
+			name: "writes the content a result carries as the object that content is",
+			results: []api.InlineQueryResult{
+				api.InlineQueryResultArticle{
+					ID:                  "r1",
+					Title:               "ёжик",
+					InputMessageContent: api.InputTextMessageContent{MessageText: "в тумане"},
+				},
+			},
+			want: `{"inline_query_id":"q1","results":[{"type":"article","id":"r1","title":"ёжик","input_message_content":{"message_text":"в тумане"}}]}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			err := api.AnswerInlineQueryMethod{
+				InlineQueryID: "q1",
+				Results:       tc.results,
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			body, err := io.ReadAll(conn.Request().Body)
+			require.NoError(t, err)
+			assert.JSONEq(
+				t,
+				tc.want,
+				string(body),
+				"a variant a carrier union admits but that holds no file must rewrite itself by marshalling, which is what writes its discriminator",
+			)
+		})
+	}
+}
+
+func TestSendAudioMethod_Call(t *testing.T) {
+	cases := []struct {
+		name      string
+		thumbnail api.InputFile
+		check     func(*testing.T, Form)
+	}{
+		{
+			name:      "sends an optional upload as a part of its own",
+			thumbnail: api.Upload{Name: "обложка.png", Reader: strings.NewReader("\x89PNG")},
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				file, ok := form.File("thumbnail")
+				require.True(t, ok, "an optional parameter that is a file must travel as a part of its own once it is given")
+				assert.Equal(
+					t,
+					FormFile{Name: "обложка.png", Content: "\x89PNG"},
+					file,
+					"a part must carry the bytes of the upload under the name the upload travels as",
+				)
+			},
+		},
+		{
+			name:      "attaches no part for an optional file left unset",
+			thumbnail: nil,
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				_, ok := form.File("thumbnail")
+				assert.False(t, ok, "an optional parameter left unset must attach no part to the request")
+			},
+		},
+		{
+			name:      "leaves no value in the body for an optional file left unset",
+			thumbnail: nil,
+			check: func(t *testing.T, form Form) {
+				t.Helper()
+				_, ok := form.Field("thumbnail")
+				assert.False(t, ok, "an optional parameter left unset must leave no value in the body, not even an empty one")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			_, err := api.SendAudioMethod{
+				ChatID:    api.ID(-1001234567890),
+				Audio:     api.Upload{Name: "трек.mp3", Reader: strings.NewReader("ID3")},
+				Thumbnail: tc.thumbnail,
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			tc.check(t, requireForm(t, conn.Request()))
+		})
+	}
+}

--- a/stands/gov2/api/files_test.go
+++ b/stands/gov2/api/files_test.go
@@ -100,6 +100,44 @@ func TestSendPhotoMethod_Call(t *testing.T) {
 	}
 }
 
+func TestSendDocumentMethod_Call(t *testing.T) {
+	cases := []struct {
+		name     string
+		markup   api.ReplyMarkup
+		entities []api.MessageEntity
+		key      string
+		want     string
+	}{
+		{
+			name:   "carries an object parameter into the body as the JSON it is",
+			markup: api.ReplyKeyboardRemove{RemoveKeyboard: true},
+			key:    "reply_markup",
+			want:   `{"remove_keyboard":true}`,
+		},
+		{
+			name:     "carries a sequence parameter into the body as the JSON it is",
+			entities: []api.MessageEntity{{Type: "bold", Offset: 0, Length: 4}},
+			key:      "caption_entities",
+			want:     `[{"type":"bold","offset":0,"length":4}]`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			_, err := api.SendDocumentMethod{
+				ChatID:          api.ID(-1001234567890),
+				Document:        api.Upload{Name: "смета.pdf", Reader: strings.NewReader("%PDF")},
+				ReplyMarkup:     tc.markup,
+				CaptionEntities: tc.entities,
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			value, ok := requireForm(t, conn.Request()).Field(tc.key)
+			require.True(t, ok, "a parameter that is not a file must ride in the body of the same request")
+			assert.JSONEq(t, tc.want, value, "a parameter that is no string must ride in the body verbatim, never quoted as one")
+		})
+	}
+}
+
 func TestSendMediaGroupMethod_Call(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/stands/gov2/api/form_test.go
+++ b/stands/gov2/api/form_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requireForm reads the request body apart as a multipart form, failing the
+// test when it cannot be read as one.
+func requireForm(t *testing.T, request *http.Request) Form {
+	t.Helper()
+	form, err := NewMultipartBody(request).Form()
+	require.NoError(t, err)
+	return form
+}
+
+// MultipartBody is the body of a captured request, taken as the multipart form
+// the request declares it to be.
+type MultipartBody struct {
+	request *http.Request
+}
+
+// NewMultipartBody creates a MultipartBody over the request whose body it reads.
+func NewMultipartBody(request *http.Request) MultipartBody {
+	return MultipartBody{request: request}
+}
+
+// Form reads the body apart into the values and the files it carries. It fails
+// when the request declares no multipart body, or the body is malformed.
+func (b MultipartBody) Form() (Form, error) {
+	_, params, err := mime.ParseMediaType(b.request.Header.Get("Content-Type"))
+	if err != nil {
+		return Form{}, fmt.Errorf("parsing content type: %w", err)
+	}
+	form := Form{fields: map[string]string{}, files: map[string]FormFile{}}
+	reader := multipart.NewReader(b.request.Body, params["boundary"])
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			return form, nil
+		}
+		if err != nil {
+			return Form{}, fmt.Errorf("reading part: %w", err)
+		}
+		content, err := io.ReadAll(part)
+		if err != nil {
+			return Form{}, fmt.Errorf("reading part %q: %w", part.FormName(), err)
+		}
+		if part.FileName() == "" {
+			form.fields[part.FormName()] = string(content)
+			continue
+		}
+		form.files[part.FormName()] = FormFile{Name: part.FileName(), Content: string(content)}
+	}
+}
+
+// Form is one multipart body read apart: the values riding in it under their
+// own keys, and the files attached to it under theirs.
+type Form struct {
+	fields map[string]string
+	files  map[string]FormFile
+}
+
+// Field returns the value the form carries under key, false when it carries
+// none.
+func (f Form) Field(key string) (string, bool) {
+	value, ok := f.fields[key]
+	return value, ok
+}
+
+// File returns the file attached to the form under key, false when none is
+// attached under it.
+func (f Form) File(key string) (FormFile, bool) {
+	file, ok := f.files[key]
+	return file, ok
+}
+
+// Attached returns every key the form carries a file under, in lexical order,
+// so that what a request attached can be stated as a whole.
+func (f Form) Attached() []string {
+	keys := make([]string, 0, len(f.files))
+	for key := range f.files {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// FormFile is one file attached to a multipart form: the name it travels under
+// and the bytes it carries.
+type FormFile struct {
+	Name    string
+	Content string
+}

--- a/stands/gov2/api/payload_test.go
+++ b/stands/gov2/api/payload_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stand/api"
+)
+
+func TestLogOutMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		check func(*testing.T, *http.Request)
+	}{
+		{
+			name: "sends a request carrying no body",
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.Empty(t, body, "a method taking no parameter must send nothing as its body")
+			},
+		},
+		{
+			name: "sends a request declaring no content type",
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				assert.Empty(
+					t,
+					req.Header.Get("Content-Type"),
+					"a method taking no parameter must declare no content type, having no body to describe",
+				)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			err := api.LogOutMethod{}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			tc.check(t, conn.Request())
+		})
+	}
+}
+
+func TestSendMessageMethod_Call(t *testing.T) {
+	cases := []struct {
+		name   string
+		chatID api.ChatID
+		check  func(*testing.T, *http.Request)
+	}{
+		{
+			name:   "sends a request declaring a JSON content type",
+			chatID: api.ID(-1001234567890),
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				assert.Equal(
+					t,
+					"application/json",
+					req.Header.Get("Content-Type"),
+					"a method reaching no file must send its parameters as JSON",
+				)
+			},
+		},
+		{
+			name:   "sends the parameters it was given and no others",
+			chatID: api.ID(-1001234567890),
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.JSONEq(
+					t,
+					`{"chat_id":-1001234567890,"text":"привет, 🐙"}`,
+					string(body),
+					"a method must marshal itself whole, leaving every optional parameter left unset out of the body",
+				)
+			},
+		},
+		{
+			name:   "addresses a chat by username as the string a username is",
+			chatID: api.Username("@ёжики"),
+			check: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.JSONEq(
+					t,
+					`{"chat_id":"@ёжики","text":"привет, 🐙"}`,
+					string(body),
+					"either way of addressing a chat must travel as the JSON it is, a number or a string, and never as a union of the two",
+				)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			_, err := api.SendMessageMethod{
+				ChatID: tc.chatID,
+				Text:   "привет, 🐙",
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			tc.check(t, conn.Request())
+		})
+	}
+}
+
+func TestSetMessageReactionMethod_Call(t *testing.T) {
+	cases := []struct {
+		name     string
+		reaction api.ReactionType
+		want     string
+	}{
+		{
+			name:     "writes the discriminator of the variant it was given",
+			reaction: api.ReactionTypeEmoji{Emoji: "👍"},
+			want:     `{"chat_id":-1001234567890,"message_id":42,"reaction":[{"type":"emoji","emoji":"👍"}]}`,
+		},
+		{
+			name:     "writes the discriminator of a variant that carries nothing else",
+			reaction: api.ReactionTypePaid{},
+			want:     `{"chat_id":-1001234567890,"message_id":42,"reaction":[{"type":"paid"}]}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			err := api.SetMessageReactionMethod{
+				ChatID:    api.ID(-1001234567890),
+				MessageID: 42,
+				Reaction:  []api.ReactionType{tc.reaction},
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			body, err := io.ReadAll(conn.Request().Body)
+			require.NoError(t, err)
+			assert.JSONEq(
+				t,
+				tc.want,
+				string(body),
+				"a variant a union tells apart must write its own discriminator without the caller naming it",
+			)
+		})
+	}
+}
+
+func TestSendRichMessageMethod_Call(t *testing.T) {
+	cases := []struct {
+		name string
+		text api.RichText
+		want string
+	}{
+		{
+			name: "writes a plain run of text as the JSON string it is",
+			text: api.RichTextPlain("простой текст"),
+			want: `"простой текст"`,
+		},
+		{
+			name: "writes a sequence of runs as a JSON array, each element as itself",
+			text: api.RichTextSequence{
+				api.RichTextPlain("начало, "),
+				api.RichTextBold{Text: api.RichTextPlain("жирный")},
+			},
+			want: `["начало, ",{"type":"bold","text":"жирный"}]`,
+		},
+		{
+			name: "writes a marked run as an object carrying its discriminator",
+			text: api.RichTextItalic{Text: api.RichTextPlain("курсив")},
+			want: `{"type":"italic","text":"курсив"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := NewCapturingConnection()
+			_, err := api.SendRichMessageMethod{
+				ChatID: api.ID(-1001234567890),
+				RichMessage: api.InputRichMessage{
+					Blocks: []api.InputRichBlock{api.InputRichBlockParagraph{Text: tc.text}},
+				},
+			}.Call(context.Background(), conn)
+			require.NoError(t, err)
+			body, err := io.ReadAll(conn.Request().Body)
+			require.NoError(t, err)
+			assert.JSONEq(
+				t,
+				`{"chat_id":-1001234567890,"rich_message":{"blocks":[{"type":"paragraph","text":`+tc.want+`}]}}`,
+				string(body),
+				"every variant of the one union written partly as prose must travel as the JSON shape that variant is",
+			)
+		})
+	}
+}

--- a/stands/gov2/api/respond_test.go
+++ b/stands/gov2/api/respond_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"stand/api"
+)
+
+// RespondingConnection implements [api.Connection] by decoding a fixed document
+// into the response of every call, which is what HTTPConnection does with the
+// result it unwrapped from the envelope. It sends nothing and asks nothing of
+// the payload.
+type RespondingConnection struct {
+	data string
+}
+
+// NewRespondingConnection creates a RespondingConnection answering every call
+// with data.
+func NewRespondingConnection(data string) RespondingConnection {
+	return RespondingConnection{data: data}
+}
+
+// Do decodes the fixed document into response. It returns an error when the
+// document does not fit what the call expects.
+func (c RespondingConnection) Do(_ context.Context, _ api.Method, _ api.Payload, response any) error {
+	return json.Unmarshal([]byte(c.data), response)
+}
+
+// FailingConnection implements [api.Connection] by failing every call with a
+// fixed error, so that what a method does with a failure can be watched.
+type FailingConnection struct {
+	err error
+}
+
+// NewFailingConnection creates a FailingConnection failing every call with err.
+func NewFailingConnection(err error) FailingConnection {
+	return FailingConnection{err: err}
+}
+
+// Do returns the fixed error, leaving the response untouched.
+func (c FailingConnection) Do(_ context.Context, _ api.Method, _ api.Payload, _ any) error {
+	return c.err
+}

--- a/stands/gov2/api/returns_test.go
+++ b/stands/gov2/api/returns_test.go
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stand/api"
+)
+
+const (
+	userAlisa = `{"id":1,"is_bot":false,"first_name":"Алиса"}`
+	userBoris = `{"id":2,"is_bot":false,"first_name":"Борис"}`
+)
+
+func TestGetChatMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		data  string
+		check func(*testing.T, api.ChatFullInfo)
+	}{
+		{
+			name: "decodes the value the API answered with",
+			data: `{"id":-1001234567890,"type":"supergroup","title":"ежи"}`,
+			check: func(t *testing.T, info api.ChatFullInfo) {
+				t.Helper()
+				assert.Equal(t, int64(-1001234567890), info.ID, "a method returning a value must hand back what the response held")
+			},
+		},
+		{
+			name: "dispatches every element of a union field to the variant its key names",
+			data: `{"id":1,"type":"private","available_reactions":[{"type":"emoji","emoji":"👍"},{"type":"paid"}]}`,
+			check: func(t *testing.T, info api.ChatFullInfo) {
+				t.Helper()
+				assert.Equal(
+					t,
+					[]api.ReactionType{api.ReactionTypeEmoji{Emoji: "👍"}, api.ReactionTypePaid{}},
+					info.AvailableReactions,
+					"a field holding a sequence of a union must decode element by element, each into the variant its key names",
+				)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := api.GetChatMethod{ChatID: api.ID(1)}.Call(
+				context.Background(),
+				NewRespondingConnection(tc.data),
+			)
+			require.NoError(t, err)
+			tc.check(t, info)
+		})
+	}
+}
+
+func TestGetChatMemberMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		data  string
+		check func(*testing.T, api.ChatMember, error)
+	}{
+		{
+			name: "dispatches a payload to the variant its key names",
+			data: `{"status":"creator","user":` + userAlisa + `,"is_anonymous":true}`,
+			check: func(t *testing.T, member api.ChatMember, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(
+					t,
+					api.ChatMemberOwner{
+						User:        api.User{ID: 1, IsBot: false, FirstName: "Алиса"},
+						IsAnonymous: true,
+					},
+					member,
+					"a returned union must decode into the variant its key names, carrying every field of it",
+				)
+			},
+		},
+		{
+			name: "tells two variants apart by the key alone",
+			data: `{"status":"member","user":` + userBoris + `}`,
+			check: func(t *testing.T, member api.ChatMember, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.IsType(t, api.ChatMemberMember{}, member, "a key naming another variant must decode into that variant and no other")
+			},
+		},
+		{
+			name: "refuses a key no variant answers to",
+			data: `{"status":"кот","user":` + userAlisa + `}`,
+			check: func(t *testing.T, _ api.ChatMember, err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, "unknown ChatMember", "a key no variant answers to must be refused, not guessed at")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			member, err := api.GetChatMemberMethod{ChatID: api.ID(1), UserID: 1}.Call(
+				context.Background(),
+				NewRespondingConnection(tc.data),
+			)
+			tc.check(t, member, err)
+		})
+	}
+}
+
+func TestGetChatAdministratorsMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		data  string
+		check func(*testing.T, []api.ChatMember, error)
+	}{
+		{
+			name: "decodes every element into the variant its own key names",
+			data: `[{"status":"creator","user":` + userAlisa + `,"is_anonymous":false},{"status":"member","user":` + userBoris + `}]`,
+			check: func(t *testing.T, members []api.ChatMember, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(
+					t,
+					[]api.ChatMember{
+						api.ChatMemberOwner{User: api.User{ID: 1, FirstName: "Алиса"}},
+						api.ChatMemberMember{User: api.User{ID: 2, FirstName: "Борис"}},
+					},
+					members,
+					"a returned sequence of a union must decode element by element, keeping the order the response gave",
+				)
+			},
+		},
+		{
+			name: "refuses the whole sequence when one element names no variant",
+			data: `[{"status":"creator","user":` + userAlisa + `},{"status":"кот","user":` + userBoris + `}]`,
+			check: func(t *testing.T, members []api.ChatMember, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "unknown ChatMember")
+				assert.Nil(t, members, "an element that names no variant must fail the call outright, not leave a half-decoded sequence behind")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			members, err := api.GetChatAdministratorsMethod{ChatID: api.ID(1)}.Call(
+				context.Background(),
+				NewRespondingConnection(tc.data),
+			)
+			tc.check(t, members, err)
+		})
+	}
+}
+
+func TestCloseMethod_Call(t *testing.T) {
+	failure := errors.New("соединение оборвалось")
+	cases := []struct {
+		name  string
+		conn  api.Connection
+		check func(*testing.T, error)
+	}{
+		{
+			name: "confirms a call that succeeded, with nothing to hand back",
+			conn: NewRespondingConnection(`true`),
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				assert.NoError(t, err, "a method that returns nothing but a confirmation must report success as no error at all")
+			},
+		},
+		{
+			name: "hands the failure of the connection back untouched",
+			conn: NewFailingConnection(failure),
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				assert.ErrorIs(t, err, failure, "a method must hand back the failure the connection reported, not one of its own")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, api.CloseMethod{}.Call(context.Background(), tc.conn))
+		})
+	}
+}

--- a/stands/gov2/api/unions_test.go
+++ b/stands/gov2/api/unions_test.go
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stand/api"
+)
+
+func TestEditMessageTextMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		data  string
+		check func(*testing.T, api.MaybeMessage, error)
+	}{
+		{
+			name: "reads an object back as the message that was edited",
+			data: `{"message_id":42,"date":1700000000,"chat":{"id":1,"type":"private"}}`,
+			check: func(t *testing.T, result api.MaybeMessage, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				message, ok := result.(api.Message)
+				require.True(t, ok, "an object must be read back as Message, the variant an object is")
+				assert.Equal(t, int64(42), message.MessageID, "the message read back must carry what the response held")
+			},
+		},
+		{
+			name: "reads a boolean back as the marker an inline message answers with",
+			data: `true`,
+			check: func(t *testing.T, result api.MaybeMessage, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, api.True(true), result, "a boolean must be read back as True, an object never decoding as one")
+			},
+		},
+		{
+			name: "refuses a payload that is neither",
+			data: `"ни то ни сё"`,
+			check: func(t *testing.T, _ api.MaybeMessage, err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, "cannot unmarshal", "a payload that is neither variant must be refused, not guessed at")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := api.EditMessageTextMethod{}.Call(
+				context.Background(),
+				NewRespondingConnection(tc.data),
+			)
+			tc.check(t, result, err)
+		})
+	}
+}
+
+func TestForwardMessageMethod_Call(t *testing.T) {
+	cases := []struct {
+		name  string
+		data  string
+		check func(*testing.T, api.Message, error)
+	}{
+		{
+			name: "reads a message dated from zero back as the one beyond reach",
+			data: message(`"pinned_message":{"message_id":7,"date":0,"chat":{"id":1,"type":"private"}}`),
+			check: func(t *testing.T, message api.Message, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.IsType(t, api.InaccessibleMessage{}, message.PinnedMessage, "a message dated from zero must be read back as the inaccessible one, both variants being objects")
+			},
+		},
+		{
+			name: "reads a message dated from anything else back as a message",
+			data: message(`"pinned_message":{"message_id":7,"date":1700000000,"chat":{"id":1,"type":"private"}}`),
+			check: func(t *testing.T, message api.Message, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.IsType(t, api.Message{}, message.PinnedMessage, "a message dated from anything but zero must be read back as a message")
+			},
+		},
+		{
+			name: "reads a bare string back as a plain run of text",
+			data: message(`"rich_message":{"blocks":[{"type":"paragraph","text":"простой текст"}]}`),
+			check: func(t *testing.T, message api.Message, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, api.RichTextPlain("простой текст"), paragraph(t, message), "a JSON string must be read back as the plain run of text it is")
+			},
+		},
+		{
+			name: "reads an array back as a sequence, element by element",
+			data: message(`"rich_message":{"blocks":[{"type":"paragraph","text":["начало, ","конец"]}]}`),
+			check: func(t *testing.T, message api.Message, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(
+					t,
+					api.RichTextSequence{api.RichTextPlain("начало, "), api.RichTextPlain("конец")},
+					paragraph(t, message),
+					"a JSON array must be read back as a sequence, each element read back as itself",
+				)
+			},
+		},
+		{
+			name: "reads a marked run back as the variant its key names",
+			data: message(`"rich_message":{"blocks":[{"type":"paragraph","text":{"type":"bold","text":"жирный"}}]}`),
+			check: func(t *testing.T, message api.Message, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(
+					t,
+					api.RichTextBold{Text: api.RichTextPlain("жирный")},
+					paragraph(t, message),
+					"a JSON object must be read back as the variant its key names, the run it marks read back in turn",
+				)
+			},
+		},
+		{
+			name: "reads a sequence back whatever shapes its elements are",
+			data: message(`"rich_message":{"blocks":[{"type":"paragraph","text":["начало, ",{"type":"italic","text":"курсив"}]}]}`),
+			check: func(t *testing.T, message api.Message, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(
+					t,
+					api.RichTextSequence{
+						api.RichTextPlain("начало, "),
+						api.RichTextItalic{Text: api.RichTextPlain("курсив")},
+					},
+					paragraph(t, message),
+					"a sequence must read every element back as the shape that element is, marked runs among plain ones",
+				)
+			},
+		},
+		{
+			name: "refuses a key no variant answers to",
+			data: message(`"rich_message":{"blocks":[{"type":"paragraph","text":{"type":"кот","text":"мяу"}}]}`),
+			check: func(t *testing.T, _ api.Message, err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, "unknown RichText", "a key no variant answers to must be refused, not guessed at")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			message, err := api.ForwardMessageMethod{
+				ChatID:     api.ID(1),
+				FromChatID: api.ID(2),
+				MessageID:  1,
+			}.Call(context.Background(), NewRespondingConnection(tc.data))
+			tc.check(t, message, err)
+		})
+	}
+}
+
+// message wraps one field into the smallest message a response can hold.
+func message(field string) string {
+	return `{"message_id":1,"date":1700000000,"chat":{"id":1,"type":"private"},` + field + `}`
+}
+
+// paragraph returns the text of the first block of a message, failing the test
+// when the message holds no paragraph there.
+func paragraph(t *testing.T, message api.Message) api.RichText {
+	t.Helper()
+	require.NotNil(t, message.RichMessage, "the response must have populated the rich message")
+	require.NotEmpty(t, message.RichMessage.Blocks, "the rich message must carry the block the response held")
+	block, ok := message.RichMessage.Blocks[0].(api.RichBlockParagraph)
+	require.True(t, ok, "the block must have been dispatched to the variant its key names")
+	return block.Text
+}

--- a/stands/gov2/go.mod
+++ b/stands/gov2/go.mod
@@ -4,3 +4,11 @@
 module stand
 
 go 1.23.10
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/stands/gov2/go.sum
+++ b/stands/gov2/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/stands/gov2/mise.toml
+++ b/stands/gov2/mise.toml
@@ -12,3 +12,8 @@ GOROOT = ""
 description = "Verify the generated Go code compiles"
 dir = "api"
 run = "go build ./..."
+
+[tasks.test]
+description = "Run tests for the generated nanopass Go stand"
+dir = "api"
+run = "go clean -testcache && go test -race ./..."

--- a/targets/golangv2/templates/manual.tmpl
+++ b/targets/golangv2/templates/manual.tmpl
@@ -117,9 +117,13 @@ func ({{.Name}}) sealed{{$union}}() {}
 	edited message when the bot may read it, the True marker when the message is
 	inline and beyond reach. An object never decodes as a boolean and a boolean
 	never as an object, so trying them in turn tells them apart.
+
+	The count is pinned beside the direction: trying two in turn is enough because
+	there are two, and a third would be tried by nothing written here.
 */}}
 {{- define "manual_maybemessage"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
 {{- assert (and (not .Direction.Sent) .Direction.Received) "MaybeMessage no longer travels inbound"}}
+{{- assert (eq (len .Variants) 2) "MaybeMessage no longer stands for 2 variants"}}
 {{- template "union" .}}
 
 func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
@@ -140,9 +144,14 @@ func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
 	arrives as. Both variants are objects, so trying them in turn would let the
 	first swallow the second. The documentation tells them apart by a value
 	instead: an inaccessible message always dates from zero.
+
+	The count is pinned beside the direction: a date tells these two apart and says
+	nothing about a third, which would arrive as whichever of the two its date
+	happened to match.
 */}}
 {{- define "manual_maybeinaccessiblemessage"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
 {{- assert (and (not .Direction.Sent) .Direction.Received) "MaybeInaccessibleMessage no longer travels inbound"}}
+{{- assert (eq (len .Variants) 2) "MaybeInaccessibleMessage no longer stands for 2 variants"}}
 {{- template "union" .}}
 
 func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
@@ -188,13 +197,31 @@ func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
 	text, an array is a sequence of runs, and everything else is one of the
 	variants a key tells apart.
 
-	That last switch is missing, and it is the one thing here that should not be
-	written by hand: twenty-five cases that drift the moment Telegram names a
-	twenty-sixth. Which is what a Union record cannot express yet — it drops the
-	marks of the variants that do carry them.
+	That last switch is written out here, variant by variant, and it is the one
+	thing in this file a specification could describe: twenty-five variants marked
+	under one key with values of their own, which is the shape a discriminated
+	union has. It is written by hand because the union is not one. A Union record
+	says nothing tells its variants apart and a DiscriminatedUnion says one key
+	tells every variant apart; the two partition the unions the page names, and
+	this union falls between them — twenty-five marked variants and two that are
+	not objects at all. Naming that third case is a change to the model, not to a
+	template, and it is not made here.
+
+	What the list costs is drift: a variant Telegram names tomorrow is missing
+	from it, and so is a value Telegram renames. Both come out as a refusal — the
+	key reaches the default and the decoder says it knows no such variant — which
+	is why the list can be carried by hand until the model grows the case. A
+	decoder that guessed instead could not be.
+
+	The count is pinned for the same reason the direction is: a variant added to
+	the union is a case missing from the list, and nothing but the number says so
+	while the marks stop at the model. It pins what the block can see and not what
+	it relies on — a renamed value leaves the count where it was, and comes out as
+	the refusal above.
 */}}
 {{- define "manual_richtext"}}{{/*gotype: github.com/andreychh/tgen/targets/golangv2.Union*/}}
 {{- assert (and .Direction.Sent .Direction.Received) "RichText no longer travels both ways"}}
+{{- assert (eq (len .Variants) 27) "RichText no longer stands for 27 variants"}}
 {{- template "union" .}}
 
 func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
@@ -224,6 +251,165 @@ func unmarshal{{.Name}}(data []byte) ({{.Name}}, error) {
 		}
 		return sequence, nil
 	}
-	return nil, fmt.Errorf("cannot unmarshal %s into {{.Name}}: the marked variants are not dispatched yet", data)
+	var mark struct {
+		Key string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &mark); err != nil {
+		return nil, err
+	}
+	switch mark.Key {
+	case "bold":
+		var variant RichTextBold
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "italic":
+		var variant RichTextItalic
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "underline":
+		var variant RichTextUnderline
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "strikethrough":
+		var variant RichTextStrikethrough
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "spoiler":
+		var variant RichTextSpoiler
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "date_time":
+		var variant RichTextDateTime
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "text_mention":
+		var variant RichTextTextMention
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "subscript":
+		var variant RichTextSubscript
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "superscript":
+		var variant RichTextSuperscript
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "marked":
+		var variant RichTextMarked
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "code":
+		var variant RichTextCode
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "custom_emoji":
+		var variant RichTextCustomEmoji
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "mathematical_expression":
+		var variant RichTextMathematicalExpression
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "url":
+		var variant RichTextURL
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "email_address":
+		var variant RichTextEmailAddress
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "phone_number":
+		var variant RichTextPhoneNumber
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "bank_card_number":
+		var variant RichTextBankCardNumber
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "mention":
+		var variant RichTextMention
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "hashtag":
+		var variant RichTextHashtag
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "cashtag":
+		var variant RichTextCashtag
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "bot_command":
+		var variant RichTextBotCommand
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "anchor":
+		var variant RichTextAnchor
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "anchor_link":
+		var variant RichTextAnchorLink
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "reference":
+		var variant RichTextReference
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	case "reference_link":
+		var variant RichTextReferenceLink
+		if err := json.Unmarshal(data, &variant); err != nil {
+			return nil, err
+		}
+		return variant, nil
+	default:
+		return nil, fmt.Errorf("unknown {{.Name}} %q", mark.Key)
+	}
 }
 {{- end}}


### PR DESCRIPTION
This PR gives the `gov2` stand behavioural tests of its own — 59 cases over what a generated method puts on the wire, what it reads back, and the `client.go` it talks through — and teaches `manual_richtext` to dispatch the twenty-five marked variants it used to refuse.

The switch is written out by hand because `Union` and `DiscriminatedUnion` partition the unions the page names and `RichText` falls between them, so naming that third case is a change to the model rather than to a template; the block pins its variant count instead, which turns a variant added upstream into a stopped generation rather than a case quietly missing from the list.

Part of #248