### PR TITLE
Keep the two union separators apart in the type-cell grammar

### DIFF
--- a/model/pipeline/typed/types/cursor.go
+++ b/model/pipeline/typed/types/cursor.go
@@ -10,7 +10,7 @@ type Cursor[T any] struct {
 	pos   int
 }
 
-// NewCursor constructs a Cursor positioned before the first item.
+// NewCursor constructs a Cursor over items, positioned at the first.
 func NewCursor[T any](items []T) *Cursor[T] {
 	return &Cursor[T]{
 		items: items,
@@ -42,8 +42,12 @@ func (c *Cursor[T]) Take() (T, bool) {
 	return item, true
 }
 
-// Skip consumes the current item without returning it, advancing the cursor.
+// Skip consumes the current item without returning it. An exhausted cursor is
+// left where it stands.
 func (c *Cursor[T]) Skip() {
+	if c.Done() {
+		return
+	}
 	c.pos++
 }
 

--- a/model/pipeline/typed/types/cursor_test.go
+++ b/model/pipeline/typed/types/cursor_test.go
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/andreychh/tgen/model/pipeline/typed/types"
+)
+
+func TestCursor_Peek(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []string
+		peeks int
+		want  []string
+	}{
+		{
+			name:  "shows the same item however many times it is asked",
+			items: []string{"Array", "of"},
+			peeks: 3,
+			want:  []string{"Array", "Array", "Array"},
+		},
+		{
+			name:  "shows the zero value when constructed over no items",
+			items: nil,
+			peeks: 2,
+			want:  []string{"", ""},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cursor := types.NewCursor(tc.items)
+			got := make([]string, 0, tc.peeks)
+			for range tc.peeks {
+				item, _ := cursor.Peek()
+				got = append(got, item)
+			}
+			assert.Equal(
+				t,
+				tc.want,
+				got,
+				"Cursor.Peek must show the item the cursor stands on without advancing past it",
+			)
+		})
+	}
+}
+
+func TestCursor_Take(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []string
+		takes int
+		want  []string
+	}{
+		{
+			name:  "hands out every item in the order it was given",
+			items: []string{"Array", "of", "Süßigkeit"},
+			takes: 3,
+			want:  []string{"Array", "of", "Süßigkeit"},
+		},
+		{
+			name:  "hands out nothing once the last item is consumed",
+			items: []string{"или", "и"},
+			takes: 4,
+			want:  []string{"или", "и"},
+		},
+		{
+			name:  "hands out nothing when constructed over no items",
+			items: nil,
+			takes: 2,
+			want:  nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cursor := types.NewCursor(tc.items)
+			var got []string
+			for range tc.takes {
+				item, ok := cursor.Take()
+				if !ok {
+					break
+				}
+				got = append(got, item)
+			}
+			assert.Equal(
+				t,
+				tc.want,
+				got,
+				"Cursor.Take must hand out each item once, front to back, and report none after the last",
+			)
+		})
+	}
+}
+
+func TestCursor_Skip(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []string
+		skips int
+		want  []string
+	}{
+		{
+			name:  "passes over the item the cursor stands on",
+			items: []string{"Array", "of", "Süßigkeit"},
+			skips: 1,
+			want:  []string{"of", "Süßigkeit"},
+		},
+		{
+			name:  "leaves an exhausted cursor exhausted",
+			items: []string{"или"},
+			skips: 5,
+			want:  nil,
+		},
+		{
+			name:  "leaves a cursor over no items exhausted",
+			items: nil,
+			skips: 3,
+			want:  nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cursor := types.NewCursor(tc.items)
+			for range tc.skips {
+				cursor.Skip()
+			}
+			var got []string
+			for {
+				item, ok := cursor.Take()
+				if !ok {
+					break
+				}
+				got = append(got, item)
+			}
+			assert.Equal(
+				t,
+				tc.want,
+				got,
+				"Cursor.Skip must pass over one item and leave nothing behind it reachable",
+			)
+		})
+	}
+}
+
+func TestCursor_Done(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []string
+		takes int
+		want  bool
+	}{
+		{
+			name:  "reports items left while one is still unconsumed",
+			items: []string{"Array", "of"},
+			takes: 1,
+			want:  false,
+		},
+		{
+			name:  "reports no items left once the last one is consumed",
+			items: []string{"Array", "of"},
+			takes: 2,
+			want:  true,
+		},
+		{
+			name:  "reports no items left when constructed over no items",
+			items: nil,
+			takes: 0,
+			want:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cursor := types.NewCursor(tc.items)
+			for range tc.takes {
+				cursor.Take()
+			}
+			assert.Equal(
+				t,
+				tc.want,
+				cursor.Done(),
+				"Cursor.Done must report whether any item is still there to consume",
+			)
+		})
+	}
+}

--- a/model/pipeline/typed/types/expression.go
+++ b/model/pipeline/typed/types/expression.go
@@ -3,6 +3,11 @@
 
 // Package types decodes the prose of a field's type column into a type
 // expression.
+//
+// [Expression] is the entry point: wrap the prose of a type cell and call its
+// Value method to obtain the type. Decoding runs in two stages — [Lexer] reads
+// the prose into [Token] values, and [Parser] reads those against the grammar
+// of a type cell.
 package types
 
 import (
@@ -24,13 +29,14 @@ func NewExpression(phrase prose.Phrase) Expression {
 }
 
 // Value returns the type expression decoded from the prose. It fails when the
-// prose lexes to an unknown token or does not form a valid type expression.
+// prose holds a word or a link that cannot be lexed, or when the tokens do not
+// form a single valid type expression.
 func (e Expression) Value() (typeexpr.Expression, error) {
 	tokens, err := NewLexer(e.phrase).Tokens()
 	if err != nil {
 		return nil, fmt.Errorf("lexing type expression: %w", err)
 	}
-	expr, err := NewParser(NewCursor(tokens)).Expression()
+	expr, err := NewParser(tokens).Expression()
 	if err != nil {
 		return nil, fmt.Errorf("parsing type expression: %w", err)
 	}

--- a/model/pipeline/typed/types/expression_test.go
+++ b/model/pipeline/typed/types/expression_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/typed/types"
+	"github.com/andreychh/tgen/model/primitive"
+	"github.com/andreychh/tgen/model/prose"
+	"github.com/andreychh/tgen/model/typeexpr"
+)
+
+func TestExpression_Value(t *testing.T) {
+	cases := []struct {
+		name    string
+		phrase  prose.Phrase
+		want    typeexpr.Expression
+		wantErr string
+	}{
+		{
+			name:   "decodes the two built-in types a chat identifier is written as",
+			phrase: prose.NewPhrase(plain("Integer or String")),
+			want: typeexpr.NewUnion(
+				typeexpr.NewPrimitive(primitive.Integer),
+				typeexpr.NewPrimitive(primitive.String),
+			),
+		},
+		{
+			name:   "decodes a sequence of a documented type",
+			phrase: prose.NewPhrase(plain("Array of "), anchor("MessageEntity")),
+			want:   typeexpr.NewArray(typeexpr.NewNamed(model.Reference("messageentity"))),
+		},
+		{
+			name:   "decodes the nested sequence a keyboard is written as",
+			phrase: prose.NewPhrase(plain("Array of Array of "), anchor("InlineKeyboardButton")),
+			want: typeexpr.NewArray(
+				typeexpr.NewArray(typeexpr.NewNamed(model.Reference("inlinekeyboardbutton"))),
+			),
+		},
+		{
+			name: "decodes a sequence whose element the documentation lists out",
+			phrase: prose.NewPhrase(
+				plain("Array of "),
+				anchor("InputMediaAudio"),
+				plain(", "),
+				anchor("InputMediaPhoto"),
+				plain(" and "),
+				anchor("InputMediaVideo"),
+			),
+			want: typeexpr.NewArray(typeexpr.NewUnion(
+				typeexpr.NewNamed(model.Reference("inputmediaaudio")),
+				typeexpr.NewNamed(model.Reference("inputmediaphoto")),
+				typeexpr.NewNamed(model.Reference("inputmediavideo")),
+			)),
+		},
+		{
+			name:   "decodes a choice between a documented type and a built-in one",
+			phrase: prose.NewPhrase(anchor("InputFile"), plain(" or String")),
+			want: typeexpr.NewUnion(
+				typeexpr.NewNamed(model.Reference("inputfile")),
+				typeexpr.NewPrimitive(primitive.String),
+			),
+		},
+		{
+			name:    "names the lexing stage when the prose carries a word it cannot read",
+			phrase:  prose.NewPhrase(plain("Целое")),
+			wantErr: "lexing type expression",
+		},
+		{
+			name:    "names the parsing stage when the tokens spell no single type",
+			phrase:  prose.NewPhrase(plain("Integer String")),
+			wantErr: "parsing type expression",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := types.NewExpression(tc.phrase).Value()
+			if tc.wantErr != "" {
+				assert.ErrorContains(
+					t,
+					err,
+					tc.wantErr,
+					"Expression.Value must name the stage that refused the prose",
+				)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				tc.want,
+				got,
+				"Expression.Value must decode a type cell into the type expression its prose spells",
+			)
+		})
+	}
+}

--- a/model/pipeline/typed/types/fixture_test.go
+++ b/model/pipeline/typed/types/fixture_test.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types_test
+
+import (
+	"strings"
+
+	"github.com/andreychh/tgen/model/prose"
+)
+
+// plain builds the unemphasized run of text a type cell writes its keywords and
+// built-in type words in.
+func plain(content string) prose.Text {
+	return prose.NewText(content, prose.StylePlain)
+}
+
+// anchor builds the in-page link a type cell names a documented type with,
+// addressing the section its name lowercases to.
+func anchor(name string) prose.Link {
+	return prose.NewLink(name, prose.StylePlain, "#"+strings.ToLower(name))
+}

--- a/model/pipeline/typed/types/lexer.go
+++ b/model/pipeline/typed/types/lexer.go
@@ -13,8 +13,8 @@ import (
 	"github.com/andreychh/tgen/model/typeexpr"
 )
 
-// Lexer tokenizes the prose of a type cell, recognizing built-in type words
-// through a primitive vocabulary.
+// Lexer is a tokenizer over the prose of a type cell, recognizing built-in type
+// words through a primitive vocabulary.
 type Lexer struct {
 	phrase     prose.Phrase
 	primitives typeexpr.Primitives
@@ -26,8 +26,10 @@ func NewLexer(phrase prose.Phrase) Lexer {
 	return Lexer{phrase: phrase, primitives: typeexpr.NewPrimitives()}
 }
 
-// Tokens lexes the phrase into its tokens. It fails on a non-anchor link, an
-// unknown word, or an inline that is neither text nor a link.
+// Tokens returns the tokens the phrase lexes to, in the order the prose writes
+// them. It fails on a link that is not an anchor, an inline that is neither
+// text nor a link, an "Array" that "of" does not follow, and a word that names
+// no built-in type.
 func (l Lexer) Tokens() ([]Token, error) {
 	var out []Token
 	for _, node := range l.phrase.Inlines() {
@@ -40,8 +42,8 @@ func (l Lexer) Tokens() ([]Token, error) {
 	return out, nil
 }
 
-// inline lexes a single inline node into its tokens. It fails on a non-anchor
-// link or an inline that is neither text nor a link.
+// inline returns the tokens node lexes to. It fails on a link that is not an
+// anchor and on an inline that is neither text nor a link.
 func (l Lexer) inline(node prose.Inline) ([]Token, error) {
 	switch node := node.(type) {
 	case prose.Link:
@@ -57,8 +59,9 @@ func (l Lexer) inline(node prose.Inline) ([]Token, error) {
 	}
 }
 
-// words lexes the content of a text run into its structural and primitive
-// tokens. It fails when a word is neither a keyword nor a known primitive.
+// words returns the structural and primitive tokens the content of a text run
+// lexes to. It fails on an "Array" that "of" does not follow and on a word that
+// names no built-in type.
 func (l Lexer) words(content string) ([]Token, error) {
 	var out []Token
 	cursor := NewCursor(split(content))
@@ -74,8 +77,10 @@ func (l Lexer) words(content string) ([]Token, error) {
 				return nil, errors.New(`expected "of" after "Array"`)
 			}
 			out = append(out, NewArrayOf())
-		case "or", "and", ",":
-			out = append(out, NewSeparator())
+		case "or":
+			out = append(out, NewOr())
+		case "and", ",":
+			out = append(out, NewSeries())
 		default:
 			kind, known := l.primitives.Kind(word)
 			if !known {

--- a/model/pipeline/typed/types/lexer_test.go
+++ b/model/pipeline/typed/types/lexer_test.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/typed/types"
+	"github.com/andreychh/tgen/model/primitive"
+	"github.com/andreychh/tgen/model/prose"
+)
+
+func TestLexer_Tokens(t *testing.T) {
+	cases := []struct {
+		name    string
+		phrase  prose.Phrase
+		want    []types.Token
+		wantErr bool
+	}{
+		{
+			name:   "lexes a built-in type word into a primitive token",
+			phrase: prose.NewPhrase(plain("Integer")),
+			want:   []types.Token{types.NewPrimitive(primitive.Integer)},
+		},
+		{
+			name:   "lexes an alias of a built-in type word into the kind it spells",
+			phrase: prose.NewPhrase(plain("Int")),
+			want:   []types.Token{types.NewPrimitive(primitive.Integer)},
+		},
+		{
+			name:   "lexes an anchor link into a reference token",
+			phrase: prose.NewPhrase(anchor("PhotoSize")),
+			want:   []types.Token{types.NewRef(model.Reference("photosize"))},
+		},
+		{
+			name:   "lexes the two words of the Array of prefix into one token",
+			phrase: prose.NewPhrase(plain("Array of "), anchor("PhotoSize")),
+			want: []types.Token{
+				types.NewArrayOf(),
+				types.NewRef(model.Reference("photosize")),
+			},
+		},
+		{
+			name:   "lexes or into the separator that joins whole terms",
+			phrase: prose.NewPhrase(plain("Integer or String")),
+			want: []types.Token{
+				types.NewPrimitive(primitive.Integer),
+				types.NewOr(),
+				types.NewPrimitive(primitive.String),
+			},
+		},
+		{
+			name: "lexes a comma and a closing and into list separators",
+			phrase: prose.NewPhrase(
+				anchor("InputMediaAudio"),
+				plain(", "),
+				anchor("InputMediaPhoto"),
+				plain(" and "),
+				anchor("InputMediaVideo"),
+			),
+			want: []types.Token{
+				types.NewRef(model.Reference("inputmediaaudio")),
+				types.NewSeries(),
+				types.NewRef(model.Reference("inputmediaphoto")),
+				types.NewSeries(),
+				types.NewRef(model.Reference("inputmediavideo")),
+			},
+		},
+		{
+			name:   "lexes a comma that no space surrounds",
+			phrase: prose.NewPhrase(plain("Integer,String")),
+			want: []types.Token{
+				types.NewPrimitive(primitive.Integer),
+				types.NewSeries(),
+				types.NewPrimitive(primitive.String),
+			},
+		},
+		{
+			name:   "lexes nothing from a phrase carrying no inlines",
+			phrase: prose.NewPhrase(),
+			want:   nil,
+		},
+		{
+			name: "returns error when a link addresses somewhere other than the page",
+			phrase: prose.NewPhrase(
+				prose.NewLink("File", prose.StylePlain, "https://example.org/file"),
+			),
+			wantErr: true,
+		},
+		{
+			name:    "returns error when Array is followed by a word other than of",
+			phrase:  prose.NewPhrase(plain("Array in String")),
+			wantErr: true,
+		},
+		{
+			name:    "returns error when Array closes the text run",
+			phrase:  prose.NewPhrase(plain("Array")),
+			wantErr: true,
+		},
+		{
+			name:    "returns error when a word names no built-in type",
+			phrase:  prose.NewPhrase(plain("Строка")),
+			wantErr: true,
+		},
+		{
+			name:    "returns error when an inline is neither text nor a link",
+			phrase:  prose.NewPhrase(prose.NewLineBreak()),
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := types.NewLexer(tc.phrase).Tokens()
+			if tc.wantErr {
+				assert.Error(
+					t,
+					err,
+					"Lexer.Tokens must refuse prose it cannot turn into type tokens",
+				)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				tc.want,
+				got,
+				"Lexer.Tokens must yield one token per lexical unit, in the order the prose writes them",
+			)
+		})
+	}
+}

--- a/model/pipeline/typed/types/parser.go
+++ b/model/pipeline/typed/types/parser.go
@@ -9,21 +9,23 @@ import (
 	"github.com/andreychh/tgen/model/typeexpr"
 )
 
-// Parser decodes a stream of type tokens into a type expression by recursive
-// descent. The grammar is:
+// Parser decodes a stream of [Token] values into the type expression they
+// spell. The grammar it accepts is:
 //
-//	expression := term (separator term)*
-//	term       := "Array of" expression | ref | primitive
+//	expression := term ("or" term)*
+//	term       := "Array of" element | ref | primitive
+//	element    := term (("," | "and") term)*
 //
-// Precedence is implicit in the rule layering: "Array of" recurses into a whole
-// expression, so a union inside an array (the comma-and form) binds as the
-// array's element, while a top-level union (the "or" form) joins terms.
+// The documentation writes two separators and they bind differently. An "or"
+// joins whole terms, so "Array of A or B" is a union of an array and B; a comma
+// list closed by "and" joins the members of an array's element union, so "Array
+// of A, B and C" is an array of a union.
 type Parser struct {
-	tokens *Cursor[Token]
+	tokens []Token
 }
 
-// NewParser constructs a Parser over a cursor of type-expression tokens.
-func NewParser(tokens *Cursor[Token]) Parser {
+// NewParser constructs a Parser over the tokens of one type expression.
+func NewParser(tokens []Token) Parser {
 	return Parser{tokens: tokens}
 }
 
@@ -31,27 +33,39 @@ func NewParser(tokens *Cursor[Token]) Parser {
 // It fails when the tokens are malformed or do not all form a single
 // expression.
 func (p Parser) Expression() (typeexpr.Expression, error) {
-	expr, err := p.expression()
+	cursor := NewCursor(p.tokens)
+	expr, err := p.expression(cursor)
 	if err != nil {
 		return nil, err
 	}
-	if !p.tokens.Done() {
+	if !cursor.Done() {
 		return nil, errors.New("trailing tokens after type expression")
 	}
 	return expr, nil
 }
 
-// expression parses a term, then folds any separator-joined terms that follow
-// into a Union. It fails when a term is malformed.
-func (p Parser) expression() (typeexpr.Expression, error) {
-	first, err := p.term()
+// expression parses the alternatives of a whole type, joined by "or".
+func (p Parser) expression(cursor *Cursor[Token]) (typeexpr.Expression, error) {
+	return p.union(cursor, NewOr())
+}
+
+// element parses the members of an array's element enumeration, joined by
+// commas and a closing "and".
+func (p Parser) element(cursor *Cursor[Token]) (typeexpr.Expression, error) {
+	return p.union(cursor, NewSeries())
+}
+
+// union returns the [typeexpr.Union] of every term that sep joins, or the lone
+// term when sep never follows. It fails when a term is malformed.
+func (p Parser) union(cursor *Cursor[Token], sep Token) (typeexpr.Expression, error) {
+	first, err := p.term(cursor)
 	if err != nil {
 		return nil, err
 	}
 	variants := []typeexpr.Expression{first}
-	for p.atSeparator() {
-		p.tokens.Skip()
-		next, err := p.term()
+	for p.at(cursor, sep) {
+		cursor.Skip()
+		next, err := p.term(cursor)
 		if err != nil {
 			return nil, err
 		}
@@ -63,17 +77,17 @@ func (p Parser) expression() (typeexpr.Expression, error) {
 	return typeexpr.NewUnion(variants...), nil
 }
 
-// term parses an "Array of" wrapper around a nested expression, or a single
+// term parses an "Array of" wrapper around an element enumeration, or a single
 // reference or primitive. It fails on the end of input or a token that cannot
 // begin a type.
-func (p Parser) term() (typeexpr.Expression, error) {
-	node, ok := p.tokens.Take()
+func (p Parser) term(cursor *Cursor[Token]) (typeexpr.Expression, error) {
+	node, ok := cursor.Take()
 	if !ok {
 		return nil, errors.New("expected a type, found end of input")
 	}
 	switch node := node.(type) {
 	case ArrayOf:
-		element, err := p.expression()
+		element, err := p.element(cursor)
 		if err != nil {
 			return nil, err
 		}
@@ -82,15 +96,17 @@ func (p Parser) term() (typeexpr.Expression, error) {
 		return typeexpr.NewNamed(node.Reference()), nil
 	case Primitive:
 		return typeexpr.NewPrimitive(node.Kind()), nil
-	default:
-		return nil, errors.New("expected a type")
+	case Or:
+		return nil, errors.New(`expected a type, found "or"`)
+	case Series:
+		return nil, errors.New("expected a type, found a list separator")
 	}
+	return nil, errors.New("unknown type token")
 }
 
-// atSeparator reports whether the next token is a separator, without consuming
-// it.
-func (p Parser) atSeparator() bool {
-	token, ok := p.tokens.Peek()
-	_, sep := token.(Separator)
-	return ok && sep
+// at reports whether the next token in cursor equals sep, without consuming it.
+// Every separator token is an empty struct, so equality compares the variant.
+func (p Parser) at(cursor *Cursor[Token], sep Token) bool {
+	token, ok := cursor.Peek()
+	return ok && token == sep
 }

--- a/model/pipeline/typed/types/parser_test.go
+++ b/model/pipeline/typed/types/parser_test.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 Andrey Chernykh
+// SPDX-License-Identifier: MIT
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/andreychh/tgen/model"
+	"github.com/andreychh/tgen/model/pipeline/typed/types"
+	"github.com/andreychh/tgen/model/primitive"
+	"github.com/andreychh/tgen/model/typeexpr"
+)
+
+func TestParser_Expression(t *testing.T) {
+	audio := types.NewRef(model.Reference("inputmediaaudio"))
+	photo := types.NewRef(model.Reference("inputmediaphoto"))
+	video := types.NewRef(model.Reference("inputmediavideo"))
+	namedAudio := typeexpr.NewNamed(model.Reference("inputmediaaudio"))
+	namedPhoto := typeexpr.NewNamed(model.Reference("inputmediaphoto"))
+	namedVideo := typeexpr.NewNamed(model.Reference("inputmediavideo"))
+	integer := types.NewPrimitive(primitive.Integer)
+	str := types.NewPrimitive(primitive.String)
+	cases := []struct {
+		name    string
+		tokens  []types.Token
+		want    typeexpr.Expression
+		wantErr bool
+	}{
+		{
+			name:   "returns the documented type a lone reference names",
+			tokens: []types.Token{audio},
+			want:   namedAudio,
+		},
+		{
+			name:   "returns the built-in type a lone primitive names",
+			tokens: []types.Token{integer},
+			want:   typeexpr.NewPrimitive(primitive.Integer),
+		},
+		{
+			name:   "joins the terms an or separates into one union",
+			tokens: []types.Token{integer, types.NewOr(), str},
+			want: typeexpr.NewUnion(
+				typeexpr.NewPrimitive(primitive.Integer),
+				typeexpr.NewPrimitive(primitive.String),
+			),
+		},
+		{
+			name:   "flattens a union of more than two terms into one level",
+			tokens: []types.Token{audio, types.NewOr(), photo, types.NewOr(), video},
+			want:   typeexpr.NewUnion(namedAudio, namedPhoto, namedVideo),
+		},
+		{
+			name:   "wraps the term an Array of precedes in an array",
+			tokens: []types.Token{types.NewArrayOf(), photo},
+			want:   typeexpr.NewArray(namedPhoto),
+		},
+		{
+			name:   "nests an array inside an array for a repeated Array of",
+			tokens: []types.Token{types.NewArrayOf(), types.NewArrayOf(), photo},
+			want:   typeexpr.NewArray(typeexpr.NewArray(namedPhoto)),
+		},
+		{
+			name: "keeps a list an array introduces inside that array",
+			tokens: []types.Token{
+				types.NewArrayOf(),
+				audio,
+				types.NewSeries(),
+				photo,
+				types.NewSeries(),
+				video,
+			},
+			want: typeexpr.NewArray(typeexpr.NewUnion(namedAudio, namedPhoto, namedVideo)),
+		},
+		{
+			name:   "lifts an or out of the array that precedes it",
+			tokens: []types.Token{types.NewArrayOf(), photo, types.NewOr(), video},
+			want:   typeexpr.NewUnion(typeexpr.NewArray(namedPhoto), namedVideo),
+		},
+		{
+			name:    "returns error when a list separator stands outside an array",
+			tokens:  []types.Token{audio, types.NewSeries(), photo},
+			wantErr: true,
+		},
+		{
+			name:    "returns error when a separator opens the stream",
+			tokens:  []types.Token{types.NewOr(), audio},
+			wantErr: true,
+		},
+		{
+			name:    "returns error when a separator closes the stream",
+			tokens:  []types.Token{audio, types.NewOr()},
+			wantErr: true,
+		},
+		{
+			name:    "returns error when two terms stand with no separator between them",
+			tokens:  []types.Token{audio, photo},
+			wantErr: true,
+		},
+		{
+			name:    "returns error when an Array of closes the stream",
+			tokens:  []types.Token{types.NewArrayOf()},
+			wantErr: true,
+		},
+		{
+			name:    "returns error when the stream carries no tokens",
+			tokens:  nil,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := types.NewParser(tc.tokens).Expression()
+			if tc.wantErr {
+				assert.Error(
+					t,
+					err,
+					"Parser.Expression must refuse a token stream that spells no single type",
+				)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				tc.want,
+				got,
+				"Parser.Expression must bind an or across whole terms and a list inside the array it opens",
+			)
+		})
+	}
+}
+
+func TestParser_ExpressionRepeated(t *testing.T) {
+	parser := types.NewParser([]types.Token{
+		types.NewPrimitive(primitive.Integer),
+		types.NewOr(),
+		types.NewPrimitive(primitive.String),
+	})
+	first, err := parser.Expression()
+	require.NoError(t, err)
+	second, err := parser.Expression()
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		first,
+		second,
+		"Parser.Expression must decode the same stream on every call, holding no position between them",
+	)
+}

--- a/model/pipeline/typed/types/token.go
+++ b/model/pipeline/typed/types/token.go
@@ -10,7 +10,9 @@ import (
 
 // Token is one lexical unit of a type expression. Its variants split into value
 // tokens that denote a type ([Ref], [Primitive]) and structural tokens that mark
-// composition ([ArrayOf], [Separator]).
+// composition ([ArrayOf], [Or], [Series]).
+//
+//sumtype:decl
 type Token interface {
 	isToken()
 }
@@ -32,7 +34,7 @@ func (r Ref) Reference() model.Reference {
 
 func (Ref) isToken() {}
 
-// Primitive is a built-in type word, one of the closed [primitive.Kind] set.
+// Primitive is a built-in type word, one of the closed set of [primitive.Kind].
 type Primitive struct {
 	kind primitive.Kind
 }
@@ -59,14 +61,24 @@ func NewArrayOf() ArrayOf {
 
 func (ArrayOf) isToken() {}
 
-// Separator divides the variants of a union. The spec writes it as "or" at the
-// top level and as commas with a final "and" inside an array element; all three
-// mean the same thing.
-type Separator struct{}
+// Or is the word "or", dividing the alternatives of the type as a whole.
+type Or struct{}
 
-// NewSeparator constructs a Separator token.
-func NewSeparator() Separator {
-	return Separator{}
+// NewOr constructs an Or token.
+func NewOr() Or {
+	return Or{}
 }
 
-func (Separator) isToken() {}
+func (Or) isToken() {}
+
+// Series is a comma, or the "and" that closes a comma list, dividing the
+// members of an enumeration. The documentation writes an array's element union
+// this way and a top-level union with [Or].
+type Series struct{}
+
+// NewSeries constructs a Series token.
+func NewSeries() Series {
+	return Series{}
+}
+
+func (Series) isToken() {}


### PR DESCRIPTION
This PR splits the single `Separator` token into `Or` and `Series` and gives an array's element its own grammar rule, so each form the documentation writes parses to one definite tree. It also marks `Token` as a sum type, takes the cursor out of the `Parser` constructor so `Expression` is idempotent, and adds the package's first tests. Generated output from the current documentation is byte-for-byte unchanged.

Marking `Token` as a sum type meant dropping the `default:` clause from the type switch in `term`: golangci's `default-signifies-exhaustive` defaults to true, so the exhaustiveness check was a no-op while that clause stood. `Cursor.Skip` gained a bound but no test — `pos` is unexported and no exported method tells `pos == len` from `pos > len`.

Closes #261